### PR TITLE
Fix a bug in presentation generation

### DIFF
--- a/routes/report.rb
+++ b/routes/report.rb
@@ -1402,17 +1402,16 @@ get '/report/:id/presentation' do
     @findings.each do |find|
         if find.presentation_points
             find.presentation_points.to_s.split("<paragraph>").each do |pp|
-		a = {}
+                a = {}
                 next unless pp =~ /\[\!\!/
                 img = pp.split("[!!")[1].split("!!]").first
                 a["name"] = img
                 if Attachments.first( :description => img)
                     img_p = Attachments.first( :description => img)
                 else
-                    return "#attachment {img} doesn't exist. Did you mistype something?"
+                    return "attachment #{img} from vulnerability \" #{find.title} \" doesn't exist. Did you mistype something?"
                 end
-                img_p = Attachments.first( :description => img)
-                a["link"] = "/report/#{id}/attachments/#{img_p.id}"
+                a["link"] = "/report/#{id}/attachments/"+img_p.id.to_s
                 @images.push(a)
             end
         end

--- a/routes/report.rb
+++ b/routes/report.rb
@@ -1406,6 +1406,11 @@ get '/report/:id/presentation' do
                 next unless pp =~ /\[\!\!/
                 img = pp.split("[!!")[1].split("!!]").first
                 a["name"] = img
+                if Attachments.first( :description => img)
+                    img_p = Attachments.first( :description => img)
+                else
+                    return "#attachment {img} doesn't exist. Did you mistype something?"
+                end
                 img_p = Attachments.first( :description => img)
                 a["link"] = "/report/#{id}/attachments/#{img_p.id}"
                 @images.push(a)

--- a/views/presentation.haml
+++ b/views/presentation.haml
@@ -130,6 +130,7 @@
                   %section{:style=>"vertical-align:top; text-align: left;"}
                     %h2
                       %img{ :src=> "#{imr['link']}" }
+                  - break
           %section{:style=>"vertical-align:top; text-align: left;"}
             %h2
               #{finding.title}


### PR DESCRIPTION
There's a bug when you generate a presentation : in the case you have more than one attachment for one finding, all attachements' URL will point to the last added one.
So, if for exemple you add two attachments for one finding, you will see the same image for both attachment in your presentation