### PR TITLE
Add dynamic attachment size inside report

### DIFF
--- a/helpers/image.rb
+++ b/helpers/image.rb
@@ -1,0 +1,46 @@
+class JPEG
+  attr_reader :width, :height
+  def initialize(file)
+    if file.kind_of? IO
+      examine(file)
+    else
+      File.open(file, 'rb') { |io| examine(io) }
+    end
+  end
+private
+  def examine(io)
+    class << io
+      def getc; super.bytes.first; end
+      def readchar; super.bytes.first; end
+      def readint; (readchar << 8) + readchar; end
+      def readframe; read(readint - 2); end
+      def readsof; [readint, readchar, readint, readint, readchar]; end
+      def next
+        c = readchar while c != 0xFF
+        c = readchar while c == 0xFF
+        c
+      end
+    end
+    raise 'malformed JPEG' unless io.getc == 0xFF && io.getc == 0xD8 # SOI
+    while marker = io.next
+      case marker
+        when 0xC0..0xC3, 0xC5..0xC7, 0xC9..0xCB, 0xCD..0xCF # SOF markers
+          length, @bits, @height, @width, components = io.readsof
+          raise 'malformed JPEG' unless length == 8 + components * 3
+        when 0xD9, 0xDA then  break # EOI, SOS
+        when 0xFE then        @comment = io.readframe # COM
+        when 0xE1 then        io.readframe # APP1, contains EXIF tag
+        else                  io.readframe # ignore frame
+      end
+    end
+  end
+end
+
+def jpeg?(data)
+  return data[0,4]=="\xff\xd8\xff\xe0".force_encoding(Encoding::ASCII_8BIT)
+end
+
+def png?(data)
+  return data[0,8]=="\x89\x50\x4e\x47\x0d\x0a\x1a\x0a".force_encoding(Encoding::ASCII_8BIT)
+end
+

--- a/server.rb
+++ b/server.rb
@@ -247,7 +247,7 @@ def image_insert(docx, rand_file, image, end_xml)
       width = 400
       height = 200
     end
-    while width > 740 do #fits nicely into word
+    while width > 720 do #fits nicely into word
         width = width - (width/20)
         height = height - (height/20)
     end

--- a/server.rb
+++ b/server.rb
@@ -2,6 +2,7 @@ require 'sinatra/base'
 require 'webrick/https'
 require 'openssl'
 require './model/master'
+require './helpers/image.rb'
 require 'zip'
 require 'net/ldap'
 
@@ -230,15 +231,34 @@ def image_insert(docx, rand_file, image, end_xml)
     p_id = "d#{rand(36**7).to_s(36)}"
     name = image.description
 
+    image_file = File.open(image.filename_location,'rb') 
+    img_data = image_file.read()              
+    
+    #resize picture to fit into word if it's too big
+    if jpeg?(img_data)
+      jpeg_dimension = JPEG.new(image.filename_location)
+      width = jpeg_dimension.width
+      height = jpeg_dimension.height
+    elsif png?(img_data)
+      width = IO.read(image.filename_location)[0x10..0x18].unpack('NN')[0]
+      height = IO.read(image.filename_location)[0x10..0x18].unpack('NN')[1]
+    #we don't want to break everything if another format is supported
+    else
+      width = 400
+      height = 200
+    end
+    while width > 740 do #fits nicely into word
+        width = width - (width/5)
+        height = height - (height/5)
+    end
+    image_file.close
     # insert picture into xml
-    docx << " <w:pict><v:shape id=\"myShape_#{p_id}\" type=\"#_x0000_t75\" style=\"width:400; height:200\"><v:imagedata r:id=\"#{p_id}\"/></v:shape></w:pict>"
+    docx << " <w:pict><v:shape id=\"myShape_#{p_id}\" type=\"#_x0000_t75\" style=\"width:#{width}; height:#{height}\"><v:imagedata r:id=\"#{p_id}\"/></v:shape></w:pict>"
     docx << end_xml
 
     # insert picture into zip
     exists = false
-    img_data = ""
 
-    File.open(image.filename_location, 'rb') {|file| img_data << file.read }
     Zip::File.open(rand_file) do |zipfile|
         #iterate zipfile to see if it has media dir, this could be better
         zipfile.each do |file|

--- a/server.rb
+++ b/server.rb
@@ -248,8 +248,8 @@ def image_insert(docx, rand_file, image, end_xml)
       height = 200
     end
     while width > 740 do #fits nicely into word
-        width = width - (width/5)
-        height = height - (height/5)
+        width = width - (width/20)
+        height = height - (height/20)
     end
     image_file.close
     # insert picture into xml


### PR DESCRIPTION
This modify the way attachment dimensions are chosen when added to the report : instead of hardcoding it, it now looks at the actual size of the attachment (looking manually at the bytes so that we don't need to add a gem), and will reduce it until it fits into word. This way, image added into the report shouldn't appear streched.