### PR TITLE
Add support for overall report type

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,7 +13,7 @@
     "burpmap":false, //maps burp findings to serpico findings
     "vulnmap":false, //maps vuln ids from MSF vuln db
     "finding_types": ["Web Application","Business Logic","Network Services", "Best Practice", "Compliance", "Database", "Network Internal", "Router Configuration","Social Engineering", "Physical", "Wireless", "Network Security", "System Security", "Logging and Auditing", "Imported"],
-    "report_assessment_types": ["Interne","Externe","Applicatif"],
+    "report_assessment_types": ["Network Internal","External","Web application","Physical","Social engineering","Configuration audit"],
     "logo":"/img/logo_1.svg",
     "auto_import":false, //Experimental, will automatically create new findings on import
     "chart":true, //Enabled or disable support,

--- a/config.json
+++ b/config.json
@@ -13,6 +13,7 @@
     "burpmap":false, //maps burp findings to serpico findings
     "vulnmap":false, //maps vuln ids from MSF vuln db
     "finding_types": ["Web Application","Business Logic","Network Services", "Best Practice", "Compliance", "Database", "Network Internal", "Router Configuration","Social Engineering", "Physical", "Wireless", "Network Security", "System Security", "Logging and Auditing", "Imported"],
+    "report_assessment_types": ["Interne","Externe","Applicatif"],
     "logo":"/img/logo_1.svg",
     "auto_import":false, //Experimental, will automatically create new findings on import
     "chart":true, //Enabled or disable support,

--- a/helpers/xslt_generation.rb
+++ b/helpers/xslt_generation.rb
@@ -25,6 +25,7 @@ def generate_xslt(docx)
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <xsl:output method="xml" indent="yes"/>
   <xsl:template match="/">
+  <xsl:variable name="low" select="\'abcdefghijklmnopqrstuvwxyz\'" /><xsl:variable name="up" select="\'ABCDEFGHIJKLMNOPQRSTUVWXYZ\'" />
     <xsl:processing-instruction name="mso-application">
       <xsl:text>progid="Word.Document"</xsl:text>
     </xsl:processing-instruction>'
@@ -195,7 +196,6 @@ def generate_xslt(docx)
 
 				conditions.each do |condition|
 					# add uppercase/lowercase to allow users to test for string matches (e.g. type='Database')
-					q << "<xsl:variable name=\"low\" select=\"'abcdefghijklmnopqrstuvwxyz'\" /><xsl:variable name=\"up\" select=\"'ABCDEFGHIJKLMNOPQRSTUVWXYZ'\" />" unless q.include?("<xsl:variable name=\"up\"")
 					q << "<xsl:if test=\"#{CGI.escapeHTML(condition.downcase).gsub("&amp;","&")}\">"
 				end
 				q << "<w:tr "
@@ -265,7 +265,6 @@ def generate_xslt(docx)
 			conditions.shift
 			conditions.each do |condition|
 				# add uppercase/lowercase to allow users to test for string matches (e.g. type='Database')
-				q << "<xsl:variable name=\"low\" select=\"'abcdefghijklmnopqrstuvwxyz'\" /><xsl:variable name=\"up\" select=\"'ABCDEFGHIJKLMNOPQRSTUVWXYZ'\" />" unless q.include?("<xsl:variable name=\"up\"")
 				q << "<xsl:if test=\"#{CGI.escapeHTML(condition.downcase).gsub("&amp;","&")}\">"
 			end
         else
@@ -312,13 +311,8 @@ def generate_xslt(docx)
 		end
 
 		omega = compress(omega)
-		# add uppercase/lowercase to allow users to test for string matches (e.g. type='Database')
-		cs = "<xsl:variable name=\"low\" select=\"'abcdefghijklmnopqrstuvwxyz'\" /><xsl:variable name=\"up\" select=\"'ABCDEFGHIJKLMNOPQRSTUVWXYZ'\" />"
-		if document.include?("<xsl:variable name=\"up\"") or replace[count-1].include?("<xsl:variable name=\"up\"")
-			cs = ""
-		end
 
-		x = replace[count-1].reverse.sub("</w:p>".reverse,"</w:p>#{cs}<xsl:if test=\"#{CGI.escapeHTML(omega.downcase).gsub("&amp;","&")}\">".reverse).reverse
+		x = replace[count-1].reverse.sub("</w:p>".reverse,"</w:p><xsl:if test=\"#{CGI.escapeHTML(omega.downcase).gsub("&amp;","&")}\">".reverse).reverse
 		replace[count-1] = x
 
 		replace[count]=''

--- a/model/master.rb
+++ b/model/master.rb
@@ -319,6 +319,7 @@ class Reports
     property :date, String, :length => 20
     property :report_type, String, :length => 200
     property :report_name, String, :length => 200
+	property :assessment_type, String, :length => 200
     property :consultant_name, String, :length => 200
     property :consultant_company, String, :length => 200
     property :consultant_phone, String

--- a/routes/admin.rb
+++ b/routes/admin.rb
@@ -209,9 +209,11 @@ post '/admin/config' do
 
     ft = params["finding_types"].split(",")
     udv = params["user_defined_variables"].split(",")
-
+	rat = params["report_assessment_types"].split(",")
+	
     config_options["finding_types"] = ft
     config_options["user_defined_variables"] = udv
+    config_options["report_assessment_types"] = rat
     config_options["port"] = params["port"]
     config_options["use_ssl"] = params["use_ssl"] ? true : false
     config_options["bind_address"] = params["bind_address"]

--- a/routes/report.rb
+++ b/routes/report.rb
@@ -21,6 +21,7 @@ end
 # Create a report
 get '/report/new' do
     @templates = Xslt.all
+	@assessment_types = config_options["report_assessment_types"]
     haml :new_report, :encode_html => true
 end
 
@@ -367,7 +368,8 @@ get '/report/:id/edit' do
     @report = get_report(id)
 	@templates = Xslt.all(:order => [:report_type.asc])
     @plugin_side_menu = get_plugin_list
-
+	@assessment_types = config_options["report_assessment_types"]
+	
     if @report == nil
         return "No Such Report"
     end

--- a/views/new_report.haml
+++ b/views/new_report.haml
@@ -21,6 +21,14 @@
           %td
             %input{:type => 'text', :name => 'short_company_name'}
         %tr
+        %tr
+          %td
+            Assessment Type &nbsp;
+          %td
+            %select{ :name => "assessment_type" }
+              - @assessment_types.each do |assessment_type|
+                %option #{assessment_type}
+        %tr
           %td{:style => 'width: 30%'}
             Report Type
           %td{:style => 'width: 70%'}

--- a/views/report_edit.haml
+++ b/views/report_edit.haml
@@ -28,6 +28,16 @@
                 %input{:type => 'text', :style => 'width: 90%', :name => 'report_name', :value => "#{@report.report_name}"}
             %tr
               %td{:style => 'width: 30%'}
+                Assessment Type
+              %td{:style => 'width: 70%'}
+                %select{ :name => "assessment_type" }
+                  - @assessment_types.each do |assessment_type|
+                    - if assessment_type == @report.assessment_type
+                      %option{ :selected => "selected" } #{assessment_type}
+                    - else
+                      %option #{assessment_type}
+            %tr
+              %td{:style => 'width: 30%'}
                 Full Company Name
               %td{:style => 'width: 70%'}
                 %input{:type => 'text', :style => 'width: 90%', :name => 'full_company_name', :value => "#{@report.full_company_name}"}


### PR DESCRIPTION
1. Fixed few bug with variable declaration in xslt document, which now allows the user to make condition outside of a loop.
2. Upated the report views so that the user can, when creatin or editing a report, choose an assessment type from a list fetched from the config.json file.

This can be used, among other things, to manage only one report template, in which the relevent parts are differenciated by testing the assessment type.

For example :

† translate(/report/reports/assessment_type,$up,$low)=translate('external',$up,$low) †
Text to show
¥

PS : you'll need to reupload any report template (so that a new xlst template is built) for Serpico not to raise an error