### PR TITLE
Added a confirmation message before deleting elements

### DIFF
--- a/views/add_user_report.haml
+++ b/views/add_user_report.haml
@@ -5,28 +5,38 @@
     %br
     %h3 Current Authors
     .table.table-striped
-      %table{:style => 'width: 50%'}    
+      %table{:style => 'width: 50%'}
         %tr
           %td
             #{@report.owner}
           %td
             &nbsp;
-        - if @report.authors 
+        - if @report.authors
           - @report.authors.each do |user|
             %tr
               %td
                 #{user}
               %td
                 %a{ :class => "btn btn-danger", :href => "/admin/del_user_report/#{@report.id}/#{user}"}
-                  %i{:class => 'icon-remove icon-white', :title => 'Remove Author'} 
+                  %i{:class => 'icon-remove icon-white', :title => 'Remove Author'}
 
     %br
-    %label{ :class => "control-label", :for => "add_collaborator" } 
+    %label{ :class => "control-label", :for => "add_collaborator" }
       Add Collaborator
-      %select{ :name => "author" } 
+      %select{ :name => "author" }
         - @users.each do |user|
           %option #{user.username}
-    %br    
+    %br
     %input{:type => 'submit', :value => 'Modify' }
-  
-      
+
+:javascript
+  function confirmDelete(evt) {
+    if (!confirm('Are you sure you want to permanently delete the select element ?')) {
+      evt.preventDefault();
+    }
+  }
+
+  var deleteElements = $('a.btn-danger');
+  for (var index = 0, length = deleteElements.length; index < length; index++) {
+    deleteElements[index].addEventListener('click', confirmDelete, false);
+  }

--- a/views/findings_edit.haml
+++ b/views/findings_edit.haml
@@ -165,7 +165,7 @@
           %a{:href=> '#mymodal', "data-toggle"=>'modal', :class=>'btn btn-info'}
             CVSS Vector String
         .controls
-          %input{:type => "text", :class=>"form-control", :placeholder=>"CVSS Vector String", :id=>"vs", :style=>"width:35em"}  
+          %input{:type => "text", :class=>"form-control", :placeholder=>"CVSS Vector String", :id=>"vs", :style=>"width:35em"}
         .modal{:id=>'mymodal', :class=>'modal hide fade', :tabindex=>'-1', :role=>'dialog', "aria-labelledby"=>'modal-label', "aria-hidden"=>'true'}
           .modal-header
             %button{:type=>'button', :class=>'close', "data-dismiss"=>"modal", "aria-hidden"=>"true"}
@@ -188,220 +188,220 @@
                 // AV
                 if(part.includes("AV:")){
                 if(part.includes(":L")){
-                document.getElementById('av').selectedIndex=0;        
+                document.getElementById('av').selectedIndex=0;
                 }
                 if(part.includes(":A")){
-                document.getElementById('av').selectedIndex=1;        
+                document.getElementById('av').selectedIndex=1;
                 }
                 if(part.includes(":N")){
-                document.getElementById('av').selectedIndex=2;        
+                document.getElementById('av').selectedIndex=2;
                 }
-                }        
+                }
 
                 // AC
                 if(part.includes("AC:")){
                 if(part.includes(":H")){
-                document.getElementById('ac').selectedIndex=0;        
+                document.getElementById('ac').selectedIndex=0;
                 }
                 if(part.includes(":M")){
-                document.getElementById('ac').selectedIndex=1;        
+                document.getElementById('ac').selectedIndex=1;
                 }
                 if(part.includes(":L")){
-                document.getElementById('ac').selectedIndex=2;        
+                document.getElementById('ac').selectedIndex=2;
                 }
-                }        
+                }
 
                 // AU
                 if(part.includes("AU:")){
                 if(part.includes(":M")){
-                document.getElementById('au').selectedIndex=0;        
+                document.getElementById('au').selectedIndex=0;
                 }
                 if(part.includes(":S")){
-                document.getElementById('au').selectedIndex=1;        
+                document.getElementById('au').selectedIndex=1;
                 }
                 if(part.includes(":N")){
-                document.getElementById('au').selectedIndex=2;        
+                document.getElementById('au').selectedIndex=2;
                 }
-                }        
+                }
 
                 // C
                 if(part.includes("C:")){
                 if(part.includes(":N")){
-                document.getElementById('c').selectedIndex=0;        
+                document.getElementById('c').selectedIndex=0;
                 }
                 if(part.includes(":P")){
-                document.getElementById('c').selectedIndex=1;        
+                document.getElementById('c').selectedIndex=1;
                 }
                 if(part.includes(":C")){
-                document.getElementById('c').selectedIndex=2;        
+                document.getElementById('c').selectedIndex=2;
                 }
-                }        
+                }
 
                 // I
                 if(part.includes("I:")){
                 if(part.includes(":N")){
-                document.getElementById('i').selectedIndex=0;        
+                document.getElementById('i').selectedIndex=0;
                 }
                 if(part.includes(":P")){
-                document.getElementById('i').selectedIndex=1;        
+                document.getElementById('i').selectedIndex=1;
                 }
                 if(part.includes(":C")){
-                document.getElementById('i').selectedIndex=2;        
+                document.getElementById('i').selectedIndex=2;
                 }
-                }        
+                }
 
                 // A
                 if(part.includes("A:")){
                 if(part.includes(":N")){
-                document.getElementById('a').selectedIndex=0;        
+                document.getElementById('a').selectedIndex=0;
                 }
                 if(part.includes(":P")){
-                document.getElementById('a').selectedIndex=1;        
+                document.getElementById('a').selectedIndex=1;
                 }
                 if(part.includes(":C")){
-                document.getElementById('a').selectedIndex=2;        
+                document.getElementById('a').selectedIndex=2;
                 }
-                }        
+                }
 
                 // E
                 if(part.includes("E:")){
                 if(part.includes(":ND")){
-                document.getElementById('e').selectedIndex=0;        
+                document.getElementById('e').selectedIndex=0;
                 }
                 if(part.includes(":U")){
-                document.getElementById('e').selectedIndex=1;        
+                document.getElementById('e').selectedIndex=1;
                 }
                 if(part.includes(":POC")){
-                document.getElementById('e').selectedIndex=2;        
+                document.getElementById('e').selectedIndex=2;
                 }
                 if(part.includes(":F")){
-                document.getElementById('e').selectedIndex=3;        
+                document.getElementById('e').selectedIndex=3;
                 }
                 if(part.includes(":H")){
-                document.getElementById('e').selectedIndex=4;        
+                document.getElementById('e').selectedIndex=4;
                 }
-                }        
+                }
 
                 // RL
                 if(part.includes("RL:")){
                 if(part.includes(":ND")){
-                document.getElementById('rl').selectedIndex=0;        
+                document.getElementById('rl').selectedIndex=0;
                 }
                 if(part.includes(":OF")){
-                document.getElementById('rl').selectedIndex=1;        
+                document.getElementById('rl').selectedIndex=1;
                 }
                 if(part.includes(":TF")){
-                document.getElementById('rl').selectedIndex=2;        
+                document.getElementById('rl').selectedIndex=2;
                 }
                 if(part.includes(":W")){
-                document.getElementById('rl').selectedIndex=3;        
+                document.getElementById('rl').selectedIndex=3;
                 }
                 if(part.includes(":U")){
-                document.getElementById('rl').selectedIndex=4;        
+                document.getElementById('rl').selectedIndex=4;
                 }
-                }        
+                }
 
                 // RC
                 if(part.includes("RC:")){
                 if(part.includes(":ND")){
-                document.getElementById('rc').selectedIndex=0;        
+                document.getElementById('rc').selectedIndex=0;
                 }
                 if(part.includes(":UC")){
-                document.getElementById('rc').selectedIndex=1;        
+                document.getElementById('rc').selectedIndex=1;
                 }
                 if(part.includes(":UR")){
-                document.getElementById('rc').selectedIndex=2;        
+                document.getElementById('rc').selectedIndex=2;
                 }
                 if(part.includes(":C")){
-                document.getElementById('rc').selectedIndex=3;        
+                document.getElementById('rc').selectedIndex=3;
                 }
-                }        
+                }
 
                 // CDP
                 if(part.includes("CDP:")){
                 if(part.includes(":ND")){
-                document.getElementById('cdp').selectedIndex=0;        
+                document.getElementById('cdp').selectedIndex=0;
                 }
                 if(part.includes(":N")){
-                document.getElementById('cdp').selectedIndex=1;        
+                document.getElementById('cdp').selectedIndex=1;
                 }
                 if(part.includes(":LM")){
-                document.getElementById('cdp').selectedIndex=2;        
+                document.getElementById('cdp').selectedIndex=2;
                 }
                 if(part.includes(":MH")){
-                document.getElementById('cdp').selectedIndex=3;        
+                document.getElementById('cdp').selectedIndex=3;
                 }
                 if(part.includes(":H")){
-                document.getElementById('cdp').selectedIndex=4;        
+                document.getElementById('cdp').selectedIndex=4;
                 }
-                }        
+                }
 
                 // TD
                 if(part.includes("TD:")){
                 if(part.includes(":ND")){
-                document.getElementById('td').selectedIndex=0;        
+                document.getElementById('td').selectedIndex=0;
                 }
                 if(part.includes(":N")){
-                document.getElementById('td').selectedIndex=1;        
+                document.getElementById('td').selectedIndex=1;
                 }
                 if(part.includes(":L")){
-                document.getElementById('td').selectedIndex=2;        
+                document.getElementById('td').selectedIndex=2;
                 }
                 if(part.includes(":M")){
-                document.getElementById('td').selectedIndex=3;        
+                document.getElementById('td').selectedIndex=3;
                 }
                 if(part.includes(":H")){
-                document.getElementById('td').selectedIndex=4;        
+                document.getElementById('td').selectedIndex=4;
                 }
-                }        
+                }
 
                 // CD
                 if(part.includes("CR:")){
                 if(part.includes(":ND")){
-                document.getElementById('cd').selectedIndex=0;        
+                document.getElementById('cd').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('cd').selectedIndex=1;        
+                document.getElementById('cd').selectedIndex=1;
                 }
                 if(part.includes(":M")){
-                document.getElementById('cd').selectedIndex=2;        
+                document.getElementById('cd').selectedIndex=2;
                 }
                 if(part.includes(":H")){
-                document.getElementById('cd').selectedIndex=3;        
+                document.getElementById('cd').selectedIndex=3;
                 }
-                }        
+                }
 
                 // IR
                 if(part.includes("IR:")){
                 if(part.includes(":ND")){
-                document.getElementById('ir').selectedIndex=0;        
+                document.getElementById('ir').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('ir').selectedIndex=1;        
+                document.getElementById('ir').selectedIndex=1;
                 }
                 if(part.includes(":M")){
-                document.getElementById('ir').selectedIndex=2;        
+                document.getElementById('ir').selectedIndex=2;
                 }
                 if(part.includes(":H")){
-                document.getElementById('ir').selectedIndex=3;        
+                document.getElementById('ir').selectedIndex=3;
                 }
-                }        
+                }
 
                 // AR
                 if(part.includes("AR:")){
                 if(part.includes(":ND")){
-                document.getElementById('ar').selectedIndex=0;        
+                document.getElementById('ar').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('ar').selectedIndex=1;        
+                document.getElementById('ar').selectedIndex=1;
                 }
                 if(part.includes(":M")){
-                document.getElementById('ar').selectedIndex=2;        
+                document.getElementById('ar').selectedIndex=2;
                 }
                 if(part.includes(":H")){
-                document.getElementById('ar').selectedIndex=3;        
+                document.getElementById('ar').selectedIndex=3;
                 }
-                }        
+                }
                 }}
                 var c = new CVSS("cvssboard", {
                 onchange: function() {
@@ -411,8 +411,8 @@
                 }
                 });
 
-                $("#vs").on('change keydown paste input', function(){               
-                updateDropdown(this.value);                
+                $("#vs").on('change keydown paste input', function(){
+                updateDropdown(this.value);
                 });
       .control-group
         %label{ :class => "control-label", :for => "av" } Access Vector
@@ -546,7 +546,7 @@
           %a{:href=> '#mymodal', "data-toggle"=>'modal', :class=>'btn btn-info'}
             CVSS Vector String
         .controls
-          %input{:type => "text", :class=>"form-control", :placeholder=>"CVSS Vector String", :id=>"vs", :style=>"width:35em"}  
+          %input{:type => "text", :class=>"form-control", :placeholder=>"CVSS Vector String", :id=>"vs", :style=>"width:35em"}
         .modal{:id=>'mymodal', :class=>'modal hide fade', :tabindex=>'-1', :role=>'dialog', "aria-labelledby"=>'modal-label', "aria-hidden"=>'true'}
           .modal-header
             %button{:type=>'button', :class=>'close', "data-dismiss"=>"modal", "aria-hidden"=>"true"}
@@ -559,7 +559,7 @@
             %div{ :id=>"cvssboard"}
               %script
                 function updateDropdown(score){
-                
+
                 var vector = score.trim().split("/");
                 for(var i in vector){
                 var part = vector[i];
@@ -573,326 +573,326 @@
                 // LANP
                 if(part.includes("AV:") && !part.includes("MAV:")){
                 if(part.includes(":L")){
-                document.getElementById('attack_vector').selectedIndex=0;        
+                document.getElementById('attack_vector').selectedIndex=0;
                 }
                 if(part.includes(":A")){
-                document.getElementById('attack_vector').selectedIndex=1;        
+                document.getElementById('attack_vector').selectedIndex=1;
                 }
                 if(part.includes(":N")){
-                document.getElementById('attack_vector').selectedIndex=2;        
+                document.getElementById('attack_vector').selectedIndex=2;
                 }
                 if(part.includes(":P")){
-                document.getElementById('attack_vector').selectedIndex=3;        
+                document.getElementById('attack_vector').selectedIndex=3;
                 }
-                }        
+                }
 
                 // AC
                 if(part.includes("AC:")  && !part.includes("MAC:")){
                 if(part.includes(":L")){
-                document.getElementById('attack_complexity').selectedIndex=0;        
+                document.getElementById('attack_complexity').selectedIndex=0;
                 }
                 if(part.includes(":H")){
-                document.getElementById('attack_complexity').selectedIndex=1;        
+                document.getElementById('attack_complexity').selectedIndex=1;
                 }
-                }        
+                }
 
                 // PR NLH
                 if(part.includes("PR:")  && !part.includes("MPR:")){
                 if(part.includes(":N")){
-                document.getElementById('privileges_required').selectedIndex=0;        
+                document.getElementById('privileges_required').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('privileges_required').selectedIndex=1;        
+                document.getElementById('privileges_required').selectedIndex=1;
                 }
                 if(part.includes(":H")){
-                document.getElementById('privileges_required').selectedIndex=2;        
+                document.getElementById('privileges_required').selectedIndex=2;
                 }
-                }        
+                }
 
                 // UI
                 if(part.includes("UI:")){
                 if(part.includes(":N")){
-                document.getElementById('user_interaction').selectedIndex=0;        
+                document.getElementById('user_interaction').selectedIndex=0;
                 }
                 if(part.includes(":R")){
-                document.getElementById('user_interaction').selectedIndex=1;        
+                document.getElementById('user_interaction').selectedIndex=1;
                 }
-                }        
+                }
 
                 // S
                 if(part.includes("S:")  && !part.includes("MS:")){
                 if(part.includes(":U")){
-                document.getElementById('scope').selectedIndex=0;        
+                document.getElementById('scope').selectedIndex=0;
                 }
                 if(part.includes(":C")){
-                document.getElementById('scope').selectedIndex=1;        
+                document.getElementById('scope').selectedIndex=1;
                 }
-                }        
+                }
 
                 // I
                 if(part.includes("I:")  && !part.includes("MI:")){
                 if(part.includes(":N")){
-                document.getElementById('integrity').selectedIndex=0;        
+                document.getElementById('integrity').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('integrity').selectedIndex=1;        
+                document.getElementById('integrity').selectedIndex=1;
                 }
                 if(part.includes(":H")){
-                document.getElementById('integrity').selectedIndex=2;        
+                document.getElementById('integrity').selectedIndex=2;
                 }
-                }        
+                }
 
                 // C
                 if(part.includes("C:") && !part.includes("MC:") && !part.includes("MAC:")){
                 if(part.includes(":N")){
-                document.getElementById('confidentiality-impact').selectedIndex=0;        
+                document.getElementById('confidentiality-impact').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('confidentiality-impact').selectedIndex=1;        
+                document.getElementById('confidentiality-impact').selectedIndex=1;
                 }
                 if(part.includes(":H")){
-                document.getElementById('confidentiality-impact').selectedIndex=2;        
+                document.getElementById('confidentiality-impact').selectedIndex=2;
                 }
-                }        
+                }
 
                 // A
                 if(part.includes("A:")  && !part.includes("MA:")){
                 if(part.includes(":N")){
-                document.getElementById('availability').selectedIndex=0;        
+                document.getElementById('availability').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('availability').selectedIndex=1;        
+                document.getElementById('availability').selectedIndex=1;
                 }
                 if(part.includes(":H")){
-                document.getElementById('availability').selectedIndex=2;        
+                document.getElementById('availability').selectedIndex=2;
                 }
-                }        
+                }
 
                 // Exploit Code Maturity
                 if(part.includes("E:")){
                 if(part.includes(":X")){
-                document.getElementById('exploit_maturity').selectedIndex=0;        
+                document.getElementById('exploit_maturity').selectedIndex=0;
                 }
                 if(part.includes(":U")){
-                document.getElementById('exploit_maturity').selectedIndex=1;        
+                document.getElementById('exploit_maturity').selectedIndex=1;
                 }
                 if(part.includes(":P")){
-                document.getElementById('exploit_maturity').selectedIndex=2;        
+                document.getElementById('exploit_maturity').selectedIndex=2;
                 }
                 if(part.includes(":F")){
-                document.getElementById('exploit_maturity').selectedIndex=3;        
+                document.getElementById('exploit_maturity').selectedIndex=3;
                 }
-                }        
+                }
 
 
                 // Remediation Level
                 if(part.includes("RL:")){
                 if(part.includes(":X")){
-                document.getElementById('remeditation_level').selectedIndex=0;        
+                document.getElementById('remeditation_level').selectedIndex=0;
                 }
                 if(part.includes(":O")){
-                document.getElementById('remeditation_level').selectedIndex=1;        
+                document.getElementById('remeditation_level').selectedIndex=1;
                 }
                 if(part.includes(":T")){
-                document.getElementById('remeditation_level').selectedIndex=2;        
+                document.getElementById('remeditation_level').selectedIndex=2;
                 }
                 if(part.includes(":W")){
-                document.getElementById('remeditation_level').selectedIndex=3;        
+                document.getElementById('remeditation_level').selectedIndex=3;
                 }
                 if(part.includes(":U")){
-                document.getElementById('remeditation_level').selectedIndex=4;        
+                document.getElementById('remeditation_level').selectedIndex=4;
                 }
-                }        
+                }
 
 
                 // report confidence
                 if(part.includes("RC:")){
                 if(part.includes(":X")){
-                document.getElementById('report_confidence').selectedIndex=0;        
+                document.getElementById('report_confidence').selectedIndex=0;
                 }
                 if(part.includes(":U")){
-                document.getElementById('report_confidence').selectedIndex=1;        
+                document.getElementById('report_confidence').selectedIndex=1;
                 }
                 if(part.includes(":R")){
-                document.getElementById('report_confidence').selectedIndex=2;        
+                document.getElementById('report_confidence').selectedIndex=2;
                 }
                 if(part.includes(":C")){
-                document.getElementById('report_confidence').selectedIndex=3;        
+                document.getElementById('report_confidence').selectedIndex=3;
                 }
-                }        
+                }
 
                 // confidentiality-requirement
                 if(part.includes("CR:")){
                 if(part.includes(":X")){
-                document.getElementById('confidentiality_requirement').selectedIndex=0;        
+                document.getElementById('confidentiality_requirement').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('confidentiality_requirement').selectedIndex=1;        
+                document.getElementById('confidentiality_requirement').selectedIndex=1;
                 }
                 if(part.includes(":M")){
-                document.getElementById('confidentiality_requirement').selectedIndex=2;        
+                document.getElementById('confidentiality_requirement').selectedIndex=2;
                 }
                 if(part.includes(":H")){
-                document.getElementById('confidentiality_requirement').selectedIndex=3;        
+                document.getElementById('confidentiality_requirement').selectedIndex=3;
                 }
-                }        
+                }
 
                 // integrity-requirement
                 if(part.includes("IR:")){
                 if(part.includes(":X")){
-                document.getElementById('integrity_requirement').selectedIndex=0;        
+                document.getElementById('integrity_requirement').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('integrity_requirement').selectedIndex=1;        
+                document.getElementById('integrity_requirement').selectedIndex=1;
                 }
                 if(part.includes(":M")){
-                document.getElementById('integrity_requirement').selectedIndex=2;        
+                document.getElementById('integrity_requirement').selectedIndex=2;
                 }
                 if(part.includes(":H")){
-                document.getElementById('integrity_requirement').selectedIndex=3;        
+                document.getElementById('integrity_requirement').selectedIndex=3;
                 }
-                }        
+                }
 
 
                 // integrity-requirement
                 if(part.includes("AR:")){
                 if(part.includes(":X")){
-                document.getElementById('availability_requirement').selectedIndex=0;        
+                document.getElementById('availability_requirement').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('availability_requirement').selectedIndex=1;        
+                document.getElementById('availability_requirement').selectedIndex=1;
                 }
                 if(part.includes(":M")){
-                document.getElementById('availability_requirement').selectedIndex=2;        
+                document.getElementById('availability_requirement').selectedIndex=2;
                 }
                 if(part.includes(":H")){
-                document.getElementById('availability_requirement').selectedIndex=3;        
+                document.getElementById('availability_requirement').selectedIndex=3;
                 }
-                }        
+                }
 
                 // modified-attack-vector
                 if(part.includes("MAV:")){
                 if(part.includes(":X")){
-                document.getElementById('mod_attack_vector').selectedIndex=0;        
+                document.getElementById('mod_attack_vector').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('mod_attack_vector').selectedIndex=1;        
+                document.getElementById('mod_attack_vector').selectedIndex=1;
                 }
                 if(part.includes(":A")){
-                document.getElementById('mod_attack_vector').selectedIndex=2;        
+                document.getElementById('mod_attack_vector').selectedIndex=2;
                 }
                 if(part.includes(":N")){
-                document.getElementById('mod_attack_vector').selectedIndex=3;        
+                document.getElementById('mod_attack_vector').selectedIndex=3;
                 }
                 if(part.includes(":P")){
-                document.getElementById('mod_attack_vector').selectedIndex=4;        
+                document.getElementById('mod_attack_vector').selectedIndex=4;
                 }
-                }        
+                }
 
                 // modified-attack-vector
                 if(part.includes("MAC:")){
                 if(part.includes(":X")){
-                document.getElementById('mod_attack_complexity').selectedIndex=0;        
+                document.getElementById('mod_attack_complexity').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('mod_attack_complexity').selectedIndex=1;        
+                document.getElementById('mod_attack_complexity').selectedIndex=1;
                 }
                 if(part.includes(":H")){
-                document.getElementById('mod_attack_complexity').selectedIndex=2;        
+                document.getElementById('mod_attack_complexity').selectedIndex=2;
                 }
-                }        
+                }
 
                 // modified-privileges-Required
                 if(part.includes("MPR:")){
                 if(part.includes(":X")){
-                document.getElementById('mod_privileges_required').selectedIndex=0;        
+                document.getElementById('mod_privileges_required').selectedIndex=0;
                 }
                 if(part.includes(":N")){
-                document.getElementById('mod_privileges_required').selectedIndex=1;        
+                document.getElementById('mod_privileges_required').selectedIndex=1;
                 }
                 if(part.includes(":L")){
-                document.getElementById('mod_privileges_required').selectedIndex=2;        
+                document.getElementById('mod_privileges_required').selectedIndex=2;
                 }
                 if(part.includes(":H")){
-                document.getElementById('mod_privileges_required').selectedIndex=3;        
+                document.getElementById('mod_privileges_required').selectedIndex=3;
                 }
-                }        
+                }
 
                 // modified-user-interaction
                 if(part.includes("MUI:")){
                 if(part.includes(":X")){
-                document.getElementById('mod_user_interaction').selectedIndex=0;        
+                document.getElementById('mod_user_interaction').selectedIndex=0;
                 }
                 if(part.includes(":N")){
-                document.getElementById('mod_user_interaction').selectedIndex=1;        
+                document.getElementById('mod_user_interaction').selectedIndex=1;
                 }
                 if(part.includes(":R")){
-                document.getElementById('mod_user_interaction').selectedIndex=2;        
+                document.getElementById('mod_user_interaction').selectedIndex=2;
                 }
-                }        
+                }
 
 
                 // modified-scope
                 if(part.includes("MS:")){
                 if(part.includes(":X")){
-                document.getElementById('mod_scope').selectedIndex=0;        
+                document.getElementById('mod_scope').selectedIndex=0;
                 }
                 if(part.includes(":U")){
-                document.getElementById('mod_scope').selectedIndex=1;        
+                document.getElementById('mod_scope').selectedIndex=1;
                 }
                 if(part.includes(":C")){
-                document.getElementById('mod_scope').selectedIndex=2;        
+                document.getElementById('mod_scope').selectedIndex=2;
                 }
-                }        
+                }
 
                 // modified-confidentiality
                 if(part.includes("MC:")){
                 if(part.includes(":X")){
-                document.getElementById('mod_confidentiality').selectedIndex=0;        
+                document.getElementById('mod_confidentiality').selectedIndex=0;
                 }
                 if(part.includes(":N")){
-                document.getElementById('mod_confidentiality').selectedIndex=1;        
+                document.getElementById('mod_confidentiality').selectedIndex=1;
                 }
                 if(part.includes(":L")){
-                document.getElementById('mod_confidentiality').selectedIndex=2;        
+                document.getElementById('mod_confidentiality').selectedIndex=2;
                 }
                 if(part.includes(":H")){
-                document.getElementById('mod_confidentiality').selectedIndex=3;        
+                document.getElementById('mod_confidentiality').selectedIndex=3;
                 }
-                }        
+                }
 
                 // modified-integrity
                 if(part.includes("MI:")){
                 if(part.includes(":X")){
-                document.getElementById('mod_integrity').selectedIndex=0;        
+                document.getElementById('mod_integrity').selectedIndex=0;
                 }
                 if(part.includes(":N")){
-                document.getElementById('mod_integrity').selectedIndex=1;        
+                document.getElementById('mod_integrity').selectedIndex=1;
                 }
                 if(part.includes(":L")){
-                document.getElementById('mod_integrity').selectedIndex=2;        
+                document.getElementById('mod_integrity').selectedIndex=2;
                 }
                 if(part.includes(":H")){
-                document.getElementById('mod_integrity').selectedIndex=3;        
+                document.getElementById('mod_integrity').selectedIndex=3;
                 }
-                }        
+                }
 
 
                 // modified-availability
                 if(part.includes("MA:")){
                 if(part.includes(":X")){
-                document.getElementById('mod_availability').selectedIndex=0;        
+                document.getElementById('mod_availability').selectedIndex=0;
                 }
                 if(part.includes(":N")){
-                document.getElementById('mod_availability').selectedIndex=1;        
+                document.getElementById('mod_availability').selectedIndex=1;
                 }
                 if(part.includes(":L")){
-                document.getElementById('mod_availability').selectedIndex=2;        
+                document.getElementById('mod_availability').selectedIndex=2;
                 }
                 if(part.includes(":H")){
-                document.getElementById('mod_availability').selectedIndex=3;        
+                document.getElementById('mod_availability').selectedIndex=3;
                 }
-                }        
+                }
                 }}
 
                 var c = new CVSS("cvssboard", {
@@ -902,8 +902,8 @@
                 }
                 });
 
-                $("#vs").on('change keydown paste input', function(){               
-                updateDropdown(this.value);                
+                $("#vs").on('change keydown paste input', function(){
+                updateDropdown(this.value);
                 });
       %span{:class=>"input-group-btn"}
       .control-group
@@ -952,7 +952,7 @@
               - else
                 %option #{scope_cvss}
       .control-group
-        %label{ :class => "control-label", :for => "confidentiality" } Confidentiality 
+        %label{ :class => "control-label", :for => "confidentiality" } Confidentiality
         .controls
           %select{ :name => "confidentiality", :id => "confidentiality-impact" }
             - options.confidentiality.each do |confidentiality|
@@ -961,7 +961,7 @@
               - else
                 %option #{confidentiality}
       .control-group
-        %label{ :class => "control-label", :for => "integrity" } Integrity 
+        %label{ :class => "control-label", :for => "integrity" } Integrity
         .controls
           %select{ :name => "integrity", :id => "integrity" }
             - options.integrity.each do |integrity|
@@ -1149,7 +1149,7 @@
           %textarea{ :rows => '3', :class => 'input-xxlarge', :id => 'likelihood_rationale', :name => 'likelihood_rationale'}
             - if @finding
               - if @finding.likelihood_rationale
-                #{meta_markup(@finding.likelihood_rationale)}      
+                #{meta_markup(@finding.likelihood_rationale)}
     - else
       .control-group
         %label{ :class => "control-label", :for => "risk" } Vulnerability Risk Level
@@ -1340,3 +1340,15 @@
     %input{:type => 'submit', :value => 'Save'}
     %a{ :href => "#{id_r}"}
       %input{ :type => "button", :value => 'Cancel'}
+
+:javascript
+  function confirmDelete(evt) {
+    if (!confirm('Are you sure you want to permanently delete the select element ?')) {
+      evt.preventDefault();
+    }
+  }
+
+  var deleteElements = $('a.btn-danger');
+  for (var index = 0, length = deleteElements.length; index < length; index++) {
+    deleteElements[index].addEventListener('click', confirmDelete, false);
+  }

--- a/views/findings_list.haml
+++ b/views/findings_list.haml
@@ -101,7 +101,7 @@
                     elsif finding.cvss_total <= 3.9
                       vulns["low"] += 1
                     end
-                  end                
+                  end
                   labels = {"label_1" => "Critical (N/A)", "label_2" => "Severe", "label_3" => "Moderate",  "label_4" => "Low"}
                 elsif @cvssv3
                   @findings.each do |finding|
@@ -115,7 +115,7 @@
                     elsif finding.cvss_total <= 3.9
                       vulns["low"] += 1
                     end
-                  end                
+                  end
                   labels = {"label_1" => "Critical", "label_2" => "Severe", "label_3" => "Moderate", "label_4" => "Low" }
                 else
                   @findings.each do |finding|
@@ -132,7 +132,7 @@
                   end
                   labels = {"label_1" => "Critical", "label_2" => "High", "label_3" => "Moderate", "label_4" => "Low", "label_5" => "Informational" }
                 end
-              - if @chart 
+              - if @chart
                 %div{:id =>"chart"}
                 %br
                 //cred to http://jsfiddle.net/ragingsquirrel3/qkHK6 for this
@@ -241,3 +241,15 @@
                       %i{:class => 'icon-arrow-up icon-white', :title => 'Add to the findings database'}
           - else
             No Findings Available
+
+:javascript
+  function confirmDelete(evt) {
+    if (!confirm('Are you sure you want to permanently delete the select element ?')) {
+      evt.preventDefault();
+    }
+  }
+
+  var deleteElements = $('a.btn-danger');
+  for (var index = 0, length = deleteElements.length; index < length; index++) {
+    deleteElements[index].addEventListener('click', confirmDelete, false);
+  }

--- a/views/list_attachments.haml
+++ b/views/list_attachments.haml
@@ -3,7 +3,7 @@
   - if @attachments
     %br
       %h3 Current Attachments
-      %br  
+      %br
       .table.table-striped
         %table{:style => 'width: 90%'}
           %tbody
@@ -15,7 +15,19 @@
                   %a{ :class => "btn btn-info", :href => "/report/#{attachment.report_id}/attachments/#{attachment.id}"}
                     %i{:class => 'icon-play-circle icon-white', :title => 'Preview'}
                   %a{ :class => "btn btn-danger", :href => "/report/#{attachment.report_id}/attachments/delete/#{attachment.id}"}
-                    %i{:class => 'icon-remove icon-white', :title => 'Delete'} 
+                    %i{:class => 'icon-remove icon-white', :title => 'Delete'}
 
   - else
     No Attachments Available.
+
+:javascript
+  function confirmDelete(evt) {
+    if (!confirm('Are you sure you want to permanently delete the select element ?')) {
+      evt.preventDefault();
+    }
+  }
+
+  var deleteElements = $('a.btn-danger');
+  for (var index = 0, length = deleteElements.length; index < length; index++) {
+    deleteElements[index].addEventListener('click', confirmDelete, false);
+  }

--- a/views/list_user.haml
+++ b/views/list_user.haml
@@ -1,7 +1,7 @@
 .span10
   %br
     %h3 Current Users
-    %br  
+    %br
     .table.table-striped
       %table{:style => 'width: 40%'}
         %tbody
@@ -14,11 +14,11 @@
                 %b
                   Level/Authentication Type
               %td{:style => 'width: 40%'}
-                Actions      
+                Actions
             - @users.each do |user|
               %tr
                 %td{ :style => 'width: 30%' }
-                  #{user.username}                  
+                  #{user.username}
                 %td{:style => 'width: 30%'}
                   #{user.type} / #{user.auth_type}
                 %td{:style => 'width: 40%'}
@@ -28,3 +28,15 @@
                     %i{:class => 'icon-pencil icon-white', :title => 'Edit Password'}
           - else
             No Users. How Curious. Who are you?
+
+:javascript
+  function confirmDelete(evt) {
+    if (!confirm('Are you sure you want to permanently delete the select element ?')) {
+      evt.preventDefault();
+    }
+  }
+
+  var deleteElements = $('a.btn-danger');
+  for (var index = 0, length = deleteElements.length; index < length; index++) {
+    deleteElements[index].addEventListener('click', confirmDelete, false);
+  }

--- a/views/reports_list.haml
+++ b/views/reports_list.haml
@@ -64,3 +64,15 @@
           - else
             %h4
               You have no reports, how about <a href="/report/new">creating</a> or <a href="/report/import">importing</a> one...
+
+:javascript
+  function confirmDelete(evt) {
+    if (!confirm('Are you sure you want to permanently delete the select element ?')) {
+      evt.preventDefault();
+    }
+  }
+
+  var deleteElements = $('a.btn-danger');
+  for (var index = 0, length = deleteElements.length; index < length; index++) {
+    deleteElements[index].addEventListener('click', confirmDelete, false);
+  }


### PR DESCRIPTION
We had a couple of mishaps with the delete buttons in the report listing page.
When you click it by accident, your whole report is gone and you have to rewrite it all over again.

I have added a confirmation message before the element gets deleted.

I have added the confirmation message in every page where there is a delete button to make the code more obvious for future contributors.

I could also add a custom tag to delete elements and move the confirmation message to the global layout to avoid code repetition if you consider this better.