### PR TITLE
keyboard shortcut for findings markup

### DIFF
--- a/public/js/format_shortcut.js
+++ b/public/js/format_shortcut.js
@@ -1,0 +1,91 @@
+window.addEventListener("load",setConvertToListListener, false)
+
+/* Escape user input before inserting it into regexp */
+function escapeRegExp(str) {
+	return str.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+}
+
+
+/* add event listener for each texterea with udvListSwitcherField class */
+function setConvertToListListener(event){
+	var elements = document.querySelectorAll("textarea.udvListSwitcherField");
+	for(var i=0; i<elements.length;i++)
+		elements[i].addEventListener("keydown",ConvertToList);
+}
+
+function removeAllTags(line, tags){
+	var matched;
+
+	for(tag in tags){
+		tags[tag].regex = new RegExp("^"+escapeRegExp(tags[tag].startTag)+".*"+escapeRegExp(tags[tag].endTag)+"$");
+	}
+	
+	do {
+		matched = false;
+		for(tag in tags){
+			if(line.match(tags[tag].regex)){
+				matched = true;
+				line = line.substr(tags[tag].startTag.length, line.length - (tags[tag].startTag.length + tags[tag].endTag.length));
+			}
+		}
+	} while(matched)
+		
+	return line
+		
+}
+
+function ConvertToList(event){
+	var listTagByKeyPressed = {
+		"w" : {"startTag": "*-", "endTag": "-*"},
+		"c" : {"startTag": "[[[", "endTag": "]]]"},
+		"x" : {"startTag": "[~~", "endTag": "~~]"},
+		"q" : {"startTag": "[==", "endTag": "==]"}
+	}
+	
+	if(event.altKey && event.ctrlKey){
+		var tags;
+		/* Check if a tag is defined for the pressed key*/
+		if(listTagByKeyPressed[event.key] === undefined)
+			return
+		else
+			tags = listTagByKeyPressed[event.key]
+		
+		/* Get the limit of the selection inside of the textarea */
+		var startSelection = event.target.selectionStart
+		var endSelection = event.target.selectionEnd
+		
+		/* Get only complete line of selected text */
+		var fullText = event.target.value
+		
+		while(fullText[startSelection-1] !== "\n" && startSelection > 0)
+			startSelection--;
+		
+		while(fullText[endSelection] !== "\n" && endSelection !== fullText.length)
+			endSelection++;
+
+		var textToEdit = fullText.slice(startSelection, endSelection)
+		
+		
+		
+		var listRow = textToEdit.split("\n");
+		
+		/* check from first line if must must add or remove tags */
+		var tagIsPresent = false;
+		
+		var regexTag = new RegExp("^"+escapeRegExp(tags.startTag)+".*"+escapeRegExp(tags.endTag)+"$");
+		
+		/* for each line, remove all tags, an if necessary, add the new tags corresponding to the pressed key */
+		if(listRow[0].match(regexTag))
+			tagIsPresent = true;
+		
+		for(var i=0; i<listRow.length; i++){
+			listRow[i] = removeAllTags(listRow[i], listTagByKeyPressed)
+
+			if(!tagIsPresent && listRow[i] !== "")
+				listRow[i] = tags.startTag + listRow[i] + tags.endTag;
+		}
+		
+		/* place the modified text in the textarea */
+		event.target.value = fullText.substr(0, startSelection) + listRow.join("\n") + fullText.substr(endSelection , fullText.length - endSelection +1)
+	}
+}

--- a/public/js/format_shortcut.js
+++ b/public/js/format_shortcut.js
@@ -6,9 +6,9 @@ function escapeRegExp(str) {
 }
 
 
-/* add event listener for each texterea with udvListSwitcherField class */
+/* add event listener for each texterea with allowMarkupShortcut class */
 function setConvertToListListener(event){
-	var elements = document.querySelectorAll("textarea.udvListSwitcherField");
+	var elements = document.querySelectorAll("textarea.allowMarkupShortcut");
 	for(var i=0; i<elements.length;i++)
 		elements[i].addEventListener("keydown",ConvertToList);
 }

--- a/views/create_finding.haml
+++ b/views/create_finding.haml
@@ -1182,7 +1182,7 @@
       .control-group
         %label{ :class => "control-label", :for => "severity_rationale" } Severity Rationale
         .controls
-          %textarea{ :rows => '3', :class => 'input-xxlarge', :id => 'severity_rationale', :name => 'severity_rationale'}
+          %textarea{ :rows => '3', :class => 'input-xxlarge udvListSwitcherField', :id => 'severity_rationale', :name => 'severity_rationale'}
       .control-group
         %label{ :class => "control-label", :for => "likelihood" } Likelihood
         .controls
@@ -1192,7 +1192,7 @@
       .control-group
         %label{ :class => "control-label", :for => "likelihood_rationale" } Likelihood Rationale
         .controls
-          %textarea{ :rows => '3', :class => 'input-xxlarge', :id => 'likelihood_rationale', :name => 'likelihood_rationale'}       
+          %textarea{ :rows => '3', :class => 'input-xxlarge udvListSwitcherField', :id => 'likelihood_rationale', :name => 'likelihood_rationale'}       
              
     - else
       .control-group
@@ -1219,9 +1219,9 @@
             %option{:value => 4}= "Critical"
     .control-group
       %label{ :class => "control-label", :for => "overview" }
-        %a{:href=> '#mymodal', "data-toggle"=>'modal', :class=>'btn btn-info'}
+        %a{:href=> '#modaloverview', "data-toggle"=>'modal', :class=>'btn btn-info'}
           Overview
-      .modal{:id=>'mymodal', :class=>'modal hide fade', :tabindex=>'-1', :role=>'dialog', "aria-labelledby"=>'modal-label', "aria-hidden"=>'true'}
+      .modal{:id=>'modaloverview', :class=>'modal hide fade', :tabindex=>'-1', :role=>'dialog', "aria-labelledby"=>'modal-label', "aria-hidden"=>'true'}
         .modal-header
           %button{:type=>'button', :class=>'close', "data-dismiss"=>"modal", "aria-hidden"=>"true"}
             x
@@ -1237,6 +1237,8 @@
           %h2
             Bullets
           %p
+            Shortcut : CTRL + ALT + w
+            %br
             Place the bulleted text inbetween a *- and a -* like so:
             %br
             %br
@@ -1245,6 +1247,8 @@
           %h2
             Paragraph Heading Text
           %p
+            Shortcut : CTRL + ALT + q
+            %br
             Place the heading inbetween a [== and a ==] like so:
             %br
             %br
@@ -1253,6 +1257,8 @@
           %h2
             Italics
           %p
+            Shortcut : CTRL + ALT + x
+            %br
             Italicize the paragraph containing [~~ and a ~~]:
             %br
             %br
@@ -1261,6 +1267,8 @@
           %h2
             Code
           %p
+            Shortcut : CTRL + ALT + c
+            %br
             Place code inbetween a [[[ and a ]]] like below. CODE CANNOT STRETCH MULTIPLE LINES.
             %br
             %br
@@ -1268,11 +1276,11 @@
               [[[ code, code goes here ]]]
 
       .controls
-        %textarea{ :rows => '10', :class => 'input-xxlarge', :id => 'overview', :name => 'overview'}
+        %textarea{ :rows => '10', :class => 'input-xxlarge udvListSwitcherField', :id => 'overview', :name => 'overview'}
     .control-group
       %label{ :class => "control-label", :for => "pocu" } Proof of Concept
       .controls
-        %textarea{ :rows => '10', :class => 'input-xxlarge', :id => 'poc', :name => 'poc', :id => 'pocu'}
+        %textarea{ :rows => '10', :class => 'input-xxlarge udvListSwitcherField', :id => 'poc', :name => 'poc', :id => 'pocu'}
     - attachments=''
     - if @attaches
       - @attaches.each do |attach|
@@ -1299,15 +1307,15 @@
       .control-group
         %label{ :class => "control-label", :for => "affected_hosts" } Affected Hosts
         .controls
-          %textarea{ :rows => '10', :class => 'input-xxlarge', :id => 'affected_hosts', :name => 'affected_hosts'}
+          %textarea{ :rows => '10', :class => 'input-xxlarge udvListSwitcherField', :id => 'affected_hosts', :name => 'affected_hosts'}
     .control-group
       %label{ :class => "control-label", :for => "remediation" } Remediation
       .controls
-        %textarea{ :rows => '10', :class => 'input-xxlarge', :name => 'remediation'}
+        %textarea{ :rows => '10', :class => 'input-xxlarge udvListSwitcherField', :name => 'remediation'}
     .control-group
       %label{ :class => "control-label", :for => "references" } References (One Per Line)
       .controls
-        %textarea{ :rows => '5', :class => 'input-xxlarge', :name => 'references'}
+        %textarea{ :rows => '5', :class => 'input-xxlarge udvListSwitcherField', :name => 'references'}
     - if !@master
       .control-group
         %label{ :class => "control-label", :for => "notes" } Notes Data
@@ -1316,7 +1324,7 @@
           %label
             Notes
           .controls
-          %textarea{ :rows => '10', :class => 'input-xxlarge', :name => 'notes'}
+          %textarea{ :rows => '10', :class => 'input-xxlarge udvListSwitcherField', :name => 'notes'}
             - if @finding
               - if @finding.notes
                 #{meta_markup(@finding.notes)}
@@ -1328,14 +1336,14 @@
           %label
             Presentation Points (One Per Line)
           .controls
-          %textarea{ :rows => '10', :class => 'input-xxlarge', :name => 'presentation_points'}
+          %textarea{ :rows => '10', :class => 'input-xxlarge udvListSwitcherField', :name => 'presentation_points'}
             - if @finding
               - if @finding.presentation_points
                 #{meta_markup(@finding.presentation_points)}
           %label
             Presentation Remediation Points (One Per Line)
           .controls
-          %textarea{ :rows => '10', :class => 'input-xxlarge', :name => 'presentation_rem_points'}
+          %textarea{ :rows => '10', :class => 'input-xxlarge udvListSwitcherField', :name => 'presentation_rem_points'}
             - if @finding
               - if @finding.presentation_rem_points
                 #{meta_markup(@finding.presentation_rem_points)}      

--- a/views/create_finding.haml
+++ b/views/create_finding.haml
@@ -1182,7 +1182,7 @@
       .control-group
         %label{ :class => "control-label", :for => "severity_rationale" } Severity Rationale
         .controls
-          %textarea{ :rows => '3', :class => 'input-xxlarge udvListSwitcherField', :id => 'severity_rationale', :name => 'severity_rationale'}
+          %textarea{ :rows => '3', :class => 'input-xxlarge allowMarkupShortcut', :id => 'severity_rationale', :name => 'severity_rationale'}
       .control-group
         %label{ :class => "control-label", :for => "likelihood" } Likelihood
         .controls
@@ -1192,7 +1192,7 @@
       .control-group
         %label{ :class => "control-label", :for => "likelihood_rationale" } Likelihood Rationale
         .controls
-          %textarea{ :rows => '3', :class => 'input-xxlarge udvListSwitcherField', :id => 'likelihood_rationale', :name => 'likelihood_rationale'}       
+          %textarea{ :rows => '3', :class => 'input-xxlarge allowMarkupShortcut', :id => 'likelihood_rationale', :name => 'likelihood_rationale'}       
              
     - else
       .control-group
@@ -1276,11 +1276,11 @@
               [[[ code, code goes here ]]]
 
       .controls
-        %textarea{ :rows => '10', :class => 'input-xxlarge udvListSwitcherField', :id => 'overview', :name => 'overview'}
+        %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :id => 'overview', :name => 'overview'}
     .control-group
       %label{ :class => "control-label", :for => "pocu" } Proof of Concept
       .controls
-        %textarea{ :rows => '10', :class => 'input-xxlarge udvListSwitcherField', :id => 'poc', :name => 'poc', :id => 'pocu'}
+        %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :id => 'poc', :name => 'poc', :id => 'pocu'}
     - attachments=''
     - if @attaches
       - @attaches.each do |attach|
@@ -1307,15 +1307,15 @@
       .control-group
         %label{ :class => "control-label", :for => "affected_hosts" } Affected Hosts
         .controls
-          %textarea{ :rows => '10', :class => 'input-xxlarge udvListSwitcherField', :id => 'affected_hosts', :name => 'affected_hosts'}
+          %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :id => 'affected_hosts', :name => 'affected_hosts'}
     .control-group
       %label{ :class => "control-label", :for => "remediation" } Remediation
       .controls
-        %textarea{ :rows => '10', :class => 'input-xxlarge udvListSwitcherField', :name => 'remediation'}
+        %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :name => 'remediation'}
     .control-group
       %label{ :class => "control-label", :for => "references" } References (One Per Line)
       .controls
-        %textarea{ :rows => '5', :class => 'input-xxlarge udvListSwitcherField', :name => 'references'}
+        %textarea{ :rows => '5', :class => 'input-xxlarge allowMarkupShortcut', :name => 'references'}
     - if !@master
       .control-group
         %label{ :class => "control-label", :for => "notes" } Notes Data
@@ -1324,7 +1324,7 @@
           %label
             Notes
           .controls
-          %textarea{ :rows => '10', :class => 'input-xxlarge udvListSwitcherField', :name => 'notes'}
+          %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :name => 'notes'}
             - if @finding
               - if @finding.notes
                 #{meta_markup(@finding.notes)}
@@ -1336,14 +1336,14 @@
           %label
             Presentation Points (One Per Line)
           .controls
-          %textarea{ :rows => '10', :class => 'input-xxlarge udvListSwitcherField', :name => 'presentation_points'}
+          %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :name => 'presentation_points'}
             - if @finding
               - if @finding.presentation_points
                 #{meta_markup(@finding.presentation_points)}
           %label
             Presentation Remediation Points (One Per Line)
           .controls
-          %textarea{ :rows => '10', :class => 'input-xxlarge udvListSwitcherField', :name => 'presentation_rem_points'}
+          %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :name => 'presentation_rem_points'}
             - if @finding
               - if @finding.presentation_rem_points
                 #{meta_markup(@finding.presentation_rem_points)}      

--- a/views/findings_edit.haml
+++ b/views/findings_edit.haml
@@ -1184,9 +1184,9 @@
               %option #{type}
     .control-group
       %label{ :class => "control-label", :for => "overview" }
-        %a{:href=> '#mymodal', "data-toggle"=>'modal', :class=>'btn btn-info'}
+        %a{:href=> '#modaloverview', "data-toggle"=>'modal', :class=>'btn btn-info'}
           Overview
-      .modal{:id=>'mymodal', :class=>'modal hide fade', :tabindex=>'-1', :role=>'dialog', "aria-labelledby"=>'modal-label', "aria-hidden"=>'true'}
+      .modal{:id=>'modaloverview', :class=>'modal hide fade', :tabindex=>'-1', :role=>'dialog', "aria-labelledby"=>'modal-label', "aria-hidden"=>'true'}
         .modal-header
           %button{:type=>'button', :class=>'close', "data-dismiss"=>"modal", "aria-hidden"=>"true"}
             x
@@ -1217,6 +1217,8 @@
           %h2
             Bullets
           %p
+            Shortcut : CTRL + ALT + w
+            %br
             Place the bulleted text inbetween a *- and a -* like so:
             %br
             %br
@@ -1225,6 +1227,8 @@
           %h2
             Paragraph Heading Text
           %p
+            Shortcut : CTRL + ALT + q
+            %br
             Place the heading inbetween a [== and a ==] like so:
             %br
             %br
@@ -1233,6 +1237,8 @@
           %h2
             Italics
           %p
+            Shortcut : CTRL + ALT + x
+            %br
             Italicize the paragraph containing [~~ and a ~~]:
             %br
             %br
@@ -1241,6 +1247,8 @@
           %h2
             Code
           %p
+            Shortcut : CTRL + ALT + c
+            %br
             Place code inbetween a [[[ and a ]]] like below. CODE CANNOT STRETCH MULTIPLE LINES.
             %br
             %br

--- a/views/findings_edit.haml
+++ b/views/findings_edit.haml
@@ -1130,7 +1130,7 @@
       .control-group
         %label{ :class => "control-label", :for => "severity_rationale" } Severity Rationale
         .controls
-          %textarea{ :rows => '3', :class => 'input-xxlarge', :id => 'severity_rationale', :name => 'severity_rationale'}
+          %textarea{ :rows => '3', :class => 'input-xxlarge udvListSwitcherField', :id => 'severity_rationale', :name => 'severity_rationale'}
             - if @finding
               - if @finding.severity_rationale
                 #{meta_markup(@finding.severity_rationale)}
@@ -1146,7 +1146,7 @@
       .control-group
         %label{ :class => "control-label", :for => "likelihood_rationale" } Likelihood Rationale
         .controls
-          %textarea{ :rows => '3', :class => 'input-xxlarge', :id => 'likelihood_rationale', :name => 'likelihood_rationale'}
+          %textarea{ :rows => '3', :class => 'input-xxlarge udvListSwitcherField', :id => 'likelihood_rationale', :name => 'likelihood_rationale'}
             - if @finding
               - if @finding.likelihood_rationale
                 #{meta_markup(@finding.likelihood_rationale)}
@@ -1255,14 +1255,14 @@
             %code
               [[[ code, code goes here ]]]
       .controls
-        %textarea{ :rows => '10', :class => 'input-xxlarge', :id => 'overview', :name => 'overview'}
+        %textarea{ :rows => '10', :class => 'input-xxlarge udvListSwitcherField', :id => 'overview', :name => 'overview'}
           - if @finding
             - if @finding.overview
               #{meta_markup(@finding.overview)}
     .control-group
       %label{ :class => "control-label", :for => "pocu" } Proof of Concept
       .controls
-        %textarea{ :rows => '10', :class => 'input-xxlarge', :name => 'poc', :id => "pocu"}
+        %textarea{ :rows => '10', :class => 'input-xxlarge udvListSwitcherField', :name => 'poc', :id => "pocu"}
           - if @finding
             - if @finding.poc
               #{meta_markup(@finding.poc)}
@@ -1293,21 +1293,21 @@
       .control-group
         %label{ :class => "control-label", :for => "affected_hosts" } Affected Hosts/URLs
         .controls
-          %textarea{ :rows => '3', :class => 'input-xxlarge', :name => 'affected_hosts'}
+          %textarea{ :rows => '3', :class => 'input-xxlarge udvListSwitcherField', :name => 'affected_hosts'}
             - if @finding
               - if @finding.affected_hosts
                 #{meta_markup(@finding.affected_hosts)}
     .control-group
       %label{ :class => "control-label", :for => "remediation" } Remediation
       .controls
-        %textarea{ :rows => '10', :class => 'input-xxlarge', :name => 'remediation'}
+        %textarea{ :rows => '10', :class => 'input-xxlarge udvListSwitcherField', :name => 'remediation'}
           - if @finding
             - if @finding.remediation
               #{meta_markup(@finding.remediation)}
     .control-group
       %label{ :class => "control-label", :for => "references" } References (One Per Line)
       .controls
-        %textarea{ :rows => '5', :class => 'input-xxlarge', :name => 'references'}
+        %textarea{ :rows => '5', :class => 'input-xxlarge udvListSwitcherField', :name => 'references'}
           - if @finding
             - if @finding.references
               #{meta_markup(@finding.references)}
@@ -1319,7 +1319,7 @@
           %label
             Notes
           .controls
-          %textarea{ :rows => '10', :class => 'input-xxlarge', :name => 'notes'}
+          %textarea{ :rows => '10', :class => 'input-xxlarge udvListSwitcherField', :name => 'notes'}
             - if @finding
               - if @finding.notes
                 #{meta_markup(@finding.notes)}
@@ -1331,14 +1331,14 @@
           %label
             Presentation Points (One Per Line)
           .controls
-          %textarea{ :rows => '10', :class => 'input-xxlarge', :name => 'presentation_points'}
+          %textarea{ :rows => '10', :class => 'input-xxlarge udvListSwitcherField', :name => 'presentation_points'}
             - if @finding
               - if @finding.presentation_points
                 #{meta_markup(@finding.presentation_points)}
           %label
             Presentation Remediation Points (One Per Line)
           .controls
-          %textarea{ :rows => '10', :class => 'input-xxlarge', :name => 'presentation_rem_points'}
+          %textarea{ :rows => '10', :class => 'input-xxlarge udvListSwitcherField', :name => 'presentation_rem_points'}
             - if @finding
               - if @finding.presentation_rem_points
                 #{meta_markup(@finding.presentation_rem_points)}

--- a/views/findings_edit.haml
+++ b/views/findings_edit.haml
@@ -1130,7 +1130,7 @@
       .control-group
         %label{ :class => "control-label", :for => "severity_rationale" } Severity Rationale
         .controls
-          %textarea{ :rows => '3', :class => 'input-xxlarge udvListSwitcherField', :id => 'severity_rationale', :name => 'severity_rationale'}
+          %textarea{ :rows => '3', :class => 'input-xxlarge allowMarkupShortcut', :id => 'severity_rationale', :name => 'severity_rationale'}
             - if @finding
               - if @finding.severity_rationale
                 #{meta_markup(@finding.severity_rationale)}
@@ -1146,7 +1146,7 @@
       .control-group
         %label{ :class => "control-label", :for => "likelihood_rationale" } Likelihood Rationale
         .controls
-          %textarea{ :rows => '3', :class => 'input-xxlarge udvListSwitcherField', :id => 'likelihood_rationale', :name => 'likelihood_rationale'}
+          %textarea{ :rows => '3', :class => 'input-xxlarge allowMarkupShortcut', :id => 'likelihood_rationale', :name => 'likelihood_rationale'}
             - if @finding
               - if @finding.likelihood_rationale
                 #{meta_markup(@finding.likelihood_rationale)}
@@ -1255,14 +1255,14 @@
             %code
               [[[ code, code goes here ]]]
       .controls
-        %textarea{ :rows => '10', :class => 'input-xxlarge udvListSwitcherField', :id => 'overview', :name => 'overview'}
+        %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :id => 'overview', :name => 'overview'}
           - if @finding
             - if @finding.overview
               #{meta_markup(@finding.overview)}
     .control-group
       %label{ :class => "control-label", :for => "pocu" } Proof of Concept
       .controls
-        %textarea{ :rows => '10', :class => 'input-xxlarge udvListSwitcherField', :name => 'poc', :id => "pocu"}
+        %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :name => 'poc', :id => "pocu"}
           - if @finding
             - if @finding.poc
               #{meta_markup(@finding.poc)}
@@ -1293,21 +1293,21 @@
       .control-group
         %label{ :class => "control-label", :for => "affected_hosts" } Affected Hosts/URLs
         .controls
-          %textarea{ :rows => '3', :class => 'input-xxlarge udvListSwitcherField', :name => 'affected_hosts'}
+          %textarea{ :rows => '3', :class => 'input-xxlarge allowMarkupShortcut', :name => 'affected_hosts'}
             - if @finding
               - if @finding.affected_hosts
                 #{meta_markup(@finding.affected_hosts)}
     .control-group
       %label{ :class => "control-label", :for => "remediation" } Remediation
       .controls
-        %textarea{ :rows => '10', :class => 'input-xxlarge udvListSwitcherField', :name => 'remediation'}
+        %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :name => 'remediation'}
           - if @finding
             - if @finding.remediation
               #{meta_markup(@finding.remediation)}
     .control-group
       %label{ :class => "control-label", :for => "references" } References (One Per Line)
       .controls
-        %textarea{ :rows => '5', :class => 'input-xxlarge udvListSwitcherField', :name => 'references'}
+        %textarea{ :rows => '5', :class => 'input-xxlarge allowMarkupShortcut', :name => 'references'}
           - if @finding
             - if @finding.references
               #{meta_markup(@finding.references)}
@@ -1319,7 +1319,7 @@
           %label
             Notes
           .controls
-          %textarea{ :rows => '10', :class => 'input-xxlarge udvListSwitcherField', :name => 'notes'}
+          %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :name => 'notes'}
             - if @finding
               - if @finding.notes
                 #{meta_markup(@finding.notes)}
@@ -1331,14 +1331,14 @@
           %label
             Presentation Points (One Per Line)
           .controls
-          %textarea{ :rows => '10', :class => 'input-xxlarge udvListSwitcherField', :name => 'presentation_points'}
+          %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :name => 'presentation_points'}
             - if @finding
               - if @finding.presentation_points
                 #{meta_markup(@finding.presentation_points)}
           %label
             Presentation Remediation Points (One Per Line)
           .controls
-          %textarea{ :rows => '10', :class => 'input-xxlarge udvListSwitcherField', :name => 'presentation_rem_points'}
+          %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :name => 'presentation_rem_points'}
             - if @finding
               - if @finding.presentation_rem_points
                 #{meta_markup(@finding.presentation_rem_points)}

--- a/views/layout.haml
+++ b/views/layout.haml
@@ -15,6 +15,7 @@
     %script{:src => "/js/bootstrap-button.js"}
     %script{:src => "/js/bootstrap-carousel.js"}
     %script{:src => "/js/bootstrap-typeahead.js"}
+    %script{:src => "/js/format_shortcut.js"}
 
     %meta{:charset => "utf-8"}/
     %title Serpico


### PR DESCRIPTION
1. Fixed a bug where in create_finding and finding_edit, the overview button activate the wrong modal
2. Added markup insertion keyboard shortcuts for create_finding and finding_edit views

This is useful to quickly modify the markup of findings fields (only works on textarea field). The shortcuts are the followings :
CTRL + ALT + w 
&nbsp;&nbsp;&nbsp;&nbsp;Mark each selected line as a bulleted line (prepend \*- , append -\*)
CTRL + ALT + q
&nbsp;&nbsp;&nbsp;&nbsp;Mark each selected line as a heading line (prepend [== , append ==])
CTRL + ALT + x
&nbsp;&nbsp;&nbsp;&nbsp;Mark each selected line as an italic line (prepend  [~~ , append  ~~])
CTRL + ALT + c
&nbsp;&nbsp;&nbsp;&nbsp;Mark each selected line as code line (prepend [[[ , append ]]])

