### PR TITLE
Support for variable in header and footer

### DIFF
--- a/helpers/helper.rb
+++ b/helpers/helper.rb
@@ -7,6 +7,25 @@ def docx_modify(rand_file,docx_xml,fil_r)
 	end
 end
 
+def find_headers_footers(docx)
+	header_footer = []
+	
+	Zip::File.open(docx) do |zip|
+		i = 1
+		while zip.find_entry("word/header#{i}.xml") != nil do
+			header_footer.push("word/header#{i}.xml")
+			i = i+1
+		end
+
+		i = 1
+		while zip.find_entry("word/footer#{i}.xml") != nil do
+			header_footer.push("word/footer#{i}.xml")
+			i = i+1
+		end
+	end
+	return header_footer
+end
+
 def read_rels(zipfile,fil_r)
 	content_types = ""
 

--- a/model/master.rb
+++ b/model/master.rb
@@ -381,7 +381,23 @@ class Xslt
     property :report_type, String, :length => 400
     property :finding_template, Boolean, :required => false, :default => false
     property :status_template, Boolean, :required => false, :default => false
+	
+	has n, :components, 'Xslt_component',
+        :parent_key => [ :id ], 
+        :child_key  => [ :xslt_id ] 
+end
 
+class Xslt_component
+    include DataMapper::Resource
+
+	property :id, Serial
+    property :xslt_location, String, :length => 400
+    property :name, String, :length => 400
+	
+	belongs_to :xslt, 'Xslt',
+		:parent_key => [ :id ],
+		:child_key  => [ :xslt_id ],
+		:required   => true
 end
 
 DataMapper.finalize

--- a/model/master.rb
+++ b/model/master.rb
@@ -382,7 +382,7 @@ class Xslt
     property :finding_template, Boolean, :required => false, :default => false
     property :status_template, Boolean, :required => false, :default => false
 	
-	has n, :components, 'Xslt_component',
+    has n, :components, 'Xslt_component',
         :parent_key => [ :id ], 
         :child_key  => [ :xslt_id ] 
 end
@@ -390,14 +390,14 @@ end
 class Xslt_component
     include DataMapper::Resource
 
-	property :id, Serial
+    property :id, Serial
     property :xslt_location, String, :length => 400
     property :name, String, :length => 400
 	
-	belongs_to :xslt, 'Xslt',
-		:parent_key => [ :id ],
-		:child_key  => [ :xslt_id ],
-		:required   => true
+    belongs_to :xslt, 'Xslt',
+        :parent_key => [ :id ],
+        :child_key  => [ :xslt_id ],
+	:required   => true
 end
 
 DataMapper.finalize

--- a/routes/report.rb
+++ b/routes/report.rb
@@ -1193,6 +1193,11 @@ get '/report/:id/generate' do
     # Create a temporary copy of the word doc
     FileUtils::copy_file(xslt_elem.docx_location,rand_file)
 
+	list_components = {}
+	xslt_elem.components.each do |component|
+		xslt = Nokogiri::XSLT(File.read(component.xslt_location))
+		list_components[component.name] = xslt.transform(Nokogiri::XML(report_xml))
+	end
     ### IMAGE INSERT CODE
     if docx_xml.to_s =~ /\[!!/
         puts "|+| Trying to insert image --- "
@@ -1242,7 +1247,10 @@ get '/report/:id/generate' do
     #### END IMAGE INSERT CODE
 
     docx_modify(rand_file, docx,'word/document.xml')
-
+	
+	list_components.each do |name, xml|
+		docx_modify(rand_file, xml.to_s,name)
+	end
     send_file rand_file, :type => 'docx', :filename => "#{@report.report_name}.docx"
 end
 


### PR DESCRIPTION
We noticed that we couldn't use the meta language inside the headers and footers of the templates, so we decided to fix that.

Currently support 2 metacharacter (probably the most usefull inside headers and footers) :
Ω
§