### PR TITLE
add metasploit data to XML

### DIFF
--- a/routes/report.rb
+++ b/routes/report.rb
@@ -1180,6 +1180,7 @@ get '/report/:id/generate' do
 
     #if msf connection up, we add services and hosts to the xml
     services_xml = ""
+    hosts_xml = ""
     if (msfsettings = RemoteEndpoints.first(:report_id => @report.id))
         if (rpc = msfrpc(@report.id))
             res = rpc.call('console.create')

--- a/routes/report.rb
+++ b/routes/report.rb
@@ -373,7 +373,7 @@ get '/report/:id/edit' do
 
     # Query for the first report matching the report_name
     @report = get_report(id)
-	  templates = Xslt.all(:order => [:report_type.asc])
+	  @templates = Xslt.all(:order => [:report_type.asc])
     @plugin_side_menu = get_plugin_list
     @assessment_types = config_options["report_assessment_types"]
 

--- a/routes/report.rb
+++ b/routes/report.rb
@@ -1198,7 +1198,7 @@ get '/report/:id/generate' do
                     end
                 end
             end
-        services_xml = services_xml_raw.doc.root.to_xml
+            services_xml = services_xml_raw.doc.root.to_xml
             #we create the XML from the hosts found.
             res = rpc.call('db.hosts', {:limit => 10000} )
             msfhosts = res["hosts"]
@@ -1213,8 +1213,8 @@ get '/report/:id/generate' do
                     end
                 end
             end
+            hosts_xml = hosts_xml_raw.doc.root.to_xml
         end
-        hosts_xml = hosts_xml_raw.doc.root.to_xml
     end
     report_xml = "<report>#{@report.to_xml}#{udv}#{findings_xml}#{services_xml}#{hosts_xml}</report>"
     xslt_elem = Xslt.first(:report_type => @report.report_type)

--- a/routes/report.rb
+++ b/routes/report.rb
@@ -281,7 +281,7 @@ post '/report/:id/upload_attachments' do
     	datax["filename"] = upf[:filename]
     	datax["description"] = CGI::escapeHTML(upf[:filename]).gsub(" ","_").gsub("/","_").gsub("\\","_").gsub("`","_")
     	datax["report_id"] = id
-        datax["caption"] = params[:caption]
+      datax["caption"] = params[:caption]
     	data = url_escape_hash(datax)
 
     	@attachment = Attachments.new(data)
@@ -373,7 +373,7 @@ get '/report/:id/edit' do
 
     # Query for the first report matching the report_name
     @report = get_report(id)
-	@templates = Xslt.all(:order => [:report_type.asc])
+	  templates = Xslt.all(:order => [:report_type.asc])
     @plugin_side_menu = get_plugin_list
     @assessment_types = config_options["report_assessment_types"]
 
@@ -422,7 +422,7 @@ get '/report/:id/user_defined_variables' do
         # add in the global UDV from config
         if config_options["user_defined_variables"].size > 0 and !@user_variables.include?(config_options["user_defined_variables"][0])
             config_options["user_defined_variables"].each do |key,value|
-                @user_variables.store(key,"")               
+                @user_variables.store(key,"")
             end
         end
 
@@ -946,7 +946,7 @@ get '/report/:id/findings/:finding_id/upload' do
                     :cvss_impact_score => @finding.cvss_impact_score,
                     :cvss_mod_impact_score => @finding.cvss_mod_impact_score,
                     :severity => @finding.severity,
-		            :likelihood => @finding.likelihood,
+		                :likelihood => @finding.likelihood,
                 }
 
     @new_finding = TemplateFindings.new(attr)
@@ -1165,7 +1165,7 @@ get '/report/:id/generate' do
         # we need the user defined variables in xml
         udv_hash = JSON.parse(@report.user_defined_variables)
     end
-    
+
     # update udv_hash with findings totals
     udv_hash = add_findings_totals(udv_hash, @findings, config_options)
 
@@ -1178,8 +1178,45 @@ get '/report/:id/generate' do
 
     udv << "</udv>"
 
-    report_xml = "<report>#{@report.to_xml}#{udv}#{findings_xml}</report>"
-
+    #if msf connection up, we add services and hosts to the xml
+    services_xml = ""
+    if (msfsettings = RemoteEndpoints.first(:report_id => @report.id))
+        if (rpc = msfrpc(@report.id))
+            res = rpc.call('console.create')
+            rpc.call('db.set_workspace', msfsettings.workspace)
+            #We create the XML from the opened services. onlyup undocumented but it does exist
+            res = rpc.call('db.services', {:limit => 10000, :only_up => true} )
+            msfservices = res["services"]
+            services_xml_raw = Nokogiri::XML::Builder.new do |xml|
+                xml.services do
+                    msfservices.each do |msfservice|
+                        xml.service do
+                            msfservice.each do |key, value|
+                                  xml.send "#{key}_", value
+                            end
+                        end
+                    end
+                end
+            end
+        services_xml = services_xml_raw.doc.root.to_xml
+            #we create the XML from the hosts found.
+            res = rpc.call('db.hosts', {:limit => 10000} )
+            msfhosts = res["hosts"]
+            hosts_xml_raw = Nokogiri::XML::Builder.new do |xml|
+                xml.hosts do
+                    msfhosts.each do |msfhost|
+                        xml.host do
+                            msfhost.each do |key, value|
+                                  xml.send "#{key}_", value
+                            end
+                        end
+                    end
+                end
+            end
+        end
+        hosts_xml = hosts_xml_raw.doc.root.to_xml
+    end
+    report_xml = "<report>#{@report.to_xml}#{udv}#{findings_xml}#{services_xml}#{hosts_xml}</report>"
     xslt_elem = Xslt.first(:report_type => @report.report_type)
 
     # Push the finding from XML to XSLT
@@ -1247,7 +1284,7 @@ get '/report/:id/generate' do
     #### END IMAGE INSERT CODE
 
     docx_modify(rand_file, docx,'word/document.xml')
-	
+
 	list_components.each do |name, xml|
 		docx_modify(rand_file, xml.to_s,name)
 	end
@@ -1421,7 +1458,18 @@ get '/report/:id/presentation' do
     redirect to("/") unless @report
 
     # add the findings
-    @findings = Findings.all(:report_id => id)
+    if(config_options["dread"])
+        @findings = Findings.all(:report_id => id, :order => [:dread_total.desc])
+    elsif(config_options["cvss"])
+        @findings = Findings.all(:report_id => id, :order => [:cvss_total.desc])
+    elsif(config_options["cvssv3"])
+        @findings = Findings.all(:report_id => id, :order => [:cvss_total.desc])
+    elsif(config_options["riskmatrix"])
+        @findings = Findings.all(:report_id => id, :order => [:risk.desc])
+    else
+        @findings = Findings.all(:report_id => id, :order => [:risk.desc])
+    end
+
 
     # add images into presentations
     @images = []
@@ -1435,7 +1483,7 @@ get '/report/:id/presentation' do
                 if Attachments.first( :description => img)
                     img_p = Attachments.first( :description => img)
                 else
-                    return "attachment #{img} from vulnerability \" #{find.title} \" doesn't exist. Did you mistype something?"
+                    return "attachment #{img} from vulnerability <a href=/report/#{find.report_id}/findings/#{find.id}/edit#pocu> #{find.title}</a> doesn't exist. Did you mistype something?"
                 end
                 a["link"] = "/report/#{id}/attachments/"+img_p.id.to_s
                 @images.push(a)
@@ -1456,16 +1504,16 @@ end
      if !(File.directory?(Dir.pwd+"/public/reveal.js"))
         return "reveal.js not found in /public/ directory. To install:<br><br> 1. Goto [INSTALL_DIR]/public/ <br>2.run 'git clone https://github.com/hakimel/reveal.js.git'<br>3. Restart Serpico"
         sleep(30)
-        redirect to("/") 
+        redirect to("/")
     end
- 
+
      id = params[:id]
- 
+
      @report = get_report(id)
- 
+
      # bail without a report
      redirect to("/") unless @report
- 
+
      # add the findings
      if(config_options["dread"])
          @findings = Findings.all(:report_id => id, :order => [:dread_total.desc])
@@ -1478,7 +1526,7 @@ end
      else
          @findings = Findings.all(:report_id => id, :order => [:risk.desc])
      end
- 
+
      # add images into presentations
      @images = []
      @findings.each do |find|
@@ -1491,7 +1539,7 @@ end
                 if Attachments.first( :description => img)
                      img_p = Attachments.first( :description => img)
                 else
-                    return "attachment #{img} from vulnerability \" #{find.title} \" doesn't exist. Did you mistype something?"
+                    return "attachment #{img} from vulnerability <a href=/report/#{find.report_id}/findings/#{find.id}/edit#pocu> #{find.title}</a> doesn't exist. Did you mistype something?"
                 end
                  a["link"] = "/report/#{id}/attachments/#{img_p.id}"
                 @images.push(a)
@@ -1502,17 +1550,17 @@ end
      @cvss = config_options["cvss"]
      @cvssv3 = config_options["cvssv3"]
      @riskmatrix = config_options["riskmatrix"]
- 	
+
      # create html file from haml template
      template = File.read(Dir.pwd+"/views/presentation.haml")
      haml_engine = Haml::Engine.new(template)
      output = haml_engine.render(Object.new, {:@report => @report, :@findings => @findings, :@dread => @dread, :@cvss => @cvss, :@cvss3 => @cvss3, :@riskmatrix => @riskmatrix, :@images => @images})
      rand_file = Dir.pwd+"/tmp/#{rand(36**12).to_s(36)}.html"
      newHTML = Nokogiri::HTML(output)
-     
+
      # Each link inside the HTML file is considered as a dependency that will need to be fixed to a relative local path
      dependencies = []
-     
+
      # fix href and src based links in the html to relative local URL. This should cover most of the use cases.
      newHTML.css('[href]').each do |el|
          if el.attribute('href').to_s[1, 6] != "report" && !(dependencies.include? el.attribute('href').to_s[1..-1])
@@ -1520,17 +1568,17 @@ end
          end
          el.set_attribute('href', '.' + el.attribute('href'))
      end
-     
+
      newHTML.css('[src]').each do |el|
          if el.attribute('src').to_s[1, 6] != "report" && !(dependencies.include? el.attribute('src').to_s[1..-1])
              dependencies.push(el.attribute('src').to_s[1..-1])
          end
          el.set_attribute('src', '.' + el.attribute('src'))
      end
-     
+
      # *slightly ugly* way to fix links in the HTML that aren't in a href or src (for exemple in javascript)
      htmlDoc = newHTML.to_html
-     # the regex match stuff like '/img/reveal.js/foo/lib.js', "/css/reveal.js/theme/special.css" 
+     # the regex match stuff like '/img/reveal.js/foo/lib.js', "/css/reveal.js/theme/special.css"
      link = htmlDoc[/(\'|\")(\/(img|js|css|reveal\.js|fonts)\/(\S*\/)*\S*\.\S*)(\'|\")/,2]
      while link != nil do
          if !dependencies.include? link[1..-1]
@@ -1539,15 +1587,15 @@ end
          htmlDoc[/(\'|\")(\/(img|js|css|reveal\.js|fonts)\/(\S*\/)*\S*\.\S*)(\'|\")/,2]= ".#{link}"
          link = htmlDoc[/(\'|\")(\/(img|js|css|reveal\.js|fonts)\/(\S*\/)*\S*\.\S*)(\'|\")/,2]
      end
-     
+
      # save html with links fixed to a relative local path
      File.open(rand_file, 'w') do |f|
          f.write htmlDoc
      end
-     
-     
+
+
      rand_zip = Dir.pwd+"/tmp/#{rand(36**12).to_s(36)}.zip"
-     
+
      # put the presentation and its dependencies (links, images, libraries...) in a zip file
      Zip.setup do |c|
          c.on_exists_proc = true
@@ -1555,7 +1603,7 @@ end
      end
      Zip::File.open(rand_zip, Zip::File::CREATE) do |zipfile|
          zipfile.add("presentation.html", rand_file)
-         
+
          # put the public directory in the zip file.
          list_public_file = Dir.glob(Dir.pwd+"/public/**/*")
          list_public_file.each do |file|
@@ -1580,15 +1628,15 @@ end
                  end
              end
          end
-         # put attachements in the zip 
+         # put attachements in the zip
          @images.each do | images|
              img_p = Attachments.first( :description => images["name"])
              zipfile.add("report/#{id}/attachments/#{img_p.id}" , img_p.filename_location)
          end
      end
-     
+
      send_file rand_zip, :type => 'zip', :filename => "#{@report.report_name}.zip"
-end 
+end
 
 # set msf rpc settings for report
 get '/report/:id/msfsettings' do
@@ -1662,6 +1710,36 @@ get '/report/:id/hosts' do
     @hosts = res["hosts"]
 
     haml :dbhosts, :encode_html => true
+end
+
+# display services from msf db
+get '/report/:id/services' do
+    id = params[:id]
+    @report = get_report(id)
+    @vulnmap = config_options["vulnmap"]
+
+    # bail without a report
+    redirect to("/") unless @report
+
+    msfsettings = RemoteEndpoints.first(:report_id => id)
+    if !msfsettings
+        return "You need to setup a metasploit RPC connection to use this feature. Do so <a href='/report/#{id}/msfsettings'>here</a>"
+    end
+
+    #setup msfrpc handler
+    rpc = msfrpc(@report.id)
+    if rpc == false
+        return "ERROR: Connection to metasploit failed. Make sure you have msfprcd running and the settings in Serpico are correct."
+    end
+
+    # get hosts from msf db
+    res = rpc.call('console.create')
+    rpc.call('db.set_workspace', msfsettings.workspace)
+    #onlyup undocumented but it does exist
+    res = rpc.call('db.services', {:limit => 10000, :only_up => true} )
+    @services = res["services"]
+
+    haml :dbservices, :encode_html => true
 end
 
 # display vulns from msf db

--- a/views/dbservices.haml
+++ b/views/dbservices.haml
@@ -1,0 +1,36 @@
+.span10
+  - if not @vulnmap
+    Metasploit integration not enabled. Contact your administrator to enable (vulnmap configuration setting)
+  - else
+    %h2 services
+    This is a read-only view of the first 10k opened services within Metasploits database.
+    %br
+    %br
+    .table.table-hover
+      %table{:style => 'width: 90%'}
+        %thead
+          %tr
+            %td
+              %b IP Address
+            %td
+              %b service Port
+            %td
+              %b service Name
+            %td
+              %b State
+            %td
+              %b Info
+        %tbody
+          - if @services
+            - @services.each do |service|
+              %tr
+                %td{:style => 'width: 15%', :"data-index" => "#{service["host"]}", :class=>"searchable"}
+                  #{service["host"]}
+                %td{:style => 'width: 15%', :"data-index" => "#{service["port"]}", :class=>"searchable"}
+                  #{service["port"]}
+                %td{:style => 'width: 15%', :"data-index" => "#{service["proto"]}", :class=>"searchable"}
+                  #{service["name"]}
+                %td{:style => 'width: 15%', :"data-index" => "#{service["state"]}", :class=>"searchable"}
+                  #{service["state"]}
+                %td{:style => 'width: 40%', :"data-index" => "#{service["info"]}", :class=>"searchable"}
+                  #{service["info"]}

--- a/views/layout.haml
+++ b/views/layout.haml
@@ -139,16 +139,18 @@
                     %a{ :href => "/report/#{@report.id}/hosts" } Hosts
                   %li
                     %a{ :href => "/report/#{@report.id}/vulns" } Vulnerabilities
+                  %li
+                    %a{ :href => "/report/#{@report.id}/services" } Services
                   %li.nav-header Additional
                   %li
                     %a{ :href => "/report/#{@report.id}/additional_features" } Additional Features
-              - if @plugin_side_menu 
+              - if @plugin_side_menu
                 %ul.nav.nav-list
-                  %li.nav-header Enabled Plugins 
+                  %li.nav-header Enabled Plugins
                   -@plugin_side_menu.each do |item|
                     %li
                     %a{ :href => "#{item["link"]}?report_id=#{@report.id}"} #{item["name"]}
-                    
+
           =yield
   - else
     %body


### PR DESCRIPTION
This PR does the following :

If vulnmap is allowed, the services and hosts data from metasploit are turned into XML and added to the XML file used by the xlst.

what this means is you can, in your template, loop through services or hosts. For exemple :

**Insert services that were discovered during the assessment :**
`æreport/services/serviceæ   ∞host∞ | ∞port∞ | ∞name∞ | ∞info∞`

**Insert hosts that were discovered during the assessment :**
`æreport/services/serviceæ   ∞address∞ | ∞os_name∞ |  ∞info∞`

**Insert number of telnet port found into the template :**
`πcount(report/services/service/port[text()='23'])π`

etc. etc.

Here's the full data accessible :

¬report/hosts/host¬
		created_at
		address
		mac
		namestate
		os_name
		os_flavor
		os_sp
		os_lang
		updated_at
		purpose
		info
∆

¬report/services/service¬
		host
		created_at
		updated_at
		port
		proto
		state
		name
		info
∆

I tested with a metasploit database containing a few thousand services, and it doesn't seem to add too much time to generate the rapport (even in the _very_ unlikely case where you cant to write all the ips to the reports, but this should be only done for assessment with a few ip in the scope really)

Only opened ports are pulled from the metasploit database.

This PR also adds a new view to access services in the same way hosts and vuln were accessible from Serpico.


