### PR TITLE
set scoring at a report level

### DIFF
--- a/helpers/asciidoc_exporter.rb
+++ b/helpers/asciidoc_exporter.rb
@@ -42,7 +42,7 @@ def gen_asciidoc(finding, score)
 	elsif(score == "cvss" or score == "cvssv3")	
 		asciidoc << "|====== \n"
 		asciidoc << "|CVSS Score Total:"
-		asciidoc << "|#{finding.total} \n"
+		asciidoc << "|#{finding.cvss_total} \n"
 		asciidoc << "|======\n\n"
 	else
 		risk = ["Informational", "Low", "Moderate", "High", "Critical"]	

--- a/helpers/asciidoc_exporter.rb
+++ b/helpers/asciidoc_exporter.rb
@@ -24,12 +24,12 @@ def parse_input(text)
 end
 
 # takes in a serpico finding and returns asciidoc version
-def gen_asciidoc(finding, dread)
+def gen_asciidoc(finding, score)
 	asciidoc = ""
 
 	asciidoc << "== #{finding.title} \n\n"
 	
-	if(dread)	
+	if(score == "dread")	
 		asciidoc << "|====== \n"
 		asciidoc << "|Damage|Reproducibility|Exploitability|Affected Users|Discoverability|Remediation Effort\n"
 		asciidoc << "|#{finding.damage} \n"
@@ -38,6 +38,11 @@ def gen_asciidoc(finding, dread)
 		asciidoc << "|#{finding.affected_users} \n"
 		asciidoc << "|#{finding.discoverability} \n"
 		asciidoc << "|#{finding.effort} \n"
+		asciidoc << "|======\n\n"
+	elsif(score == "cvss" or score == "cvssv3")	
+		asciidoc << "|====== \n"
+		asciidoc << "|CVSS Score Total:"
+		asciidoc << "|#{finding.total} \n"
 		asciidoc << "|======\n\n"
 	else
 		risk = ["Informational", "Low", "Moderate", "High", "Critical"]	

--- a/helpers/helper.rb
+++ b/helpers/helper.rb
@@ -983,3 +983,60 @@ def convert_score(finding)
 	end
 	return finding
 end
+
+# Get the type of scoring from the report and set the view variables, pull findings
+def get_scoring_findings(report)
+    if(report.scoring.downcase == "dread")
+        findings = Findings.all(:report_id => report.id, :order => [:dread_total.desc])
+        dread = true
+        cvss = false
+        cvss3 = false
+        risk = false
+        riskmatrix = false
+    elsif(report.scoring.downcase == "cvss")
+        findings = Findings.all(:report_id => report.id, :order => [:cvss_total.desc])
+        dread = false
+        cvss = true
+        cvss3 = false
+        risk = false
+        riskmatrix = false
+    elsif(report.scoring.downcase == "cvssv3")
+        findings = Findings.all(:report_id => report.id, :order => [:cvss_total.desc])
+        dread = false
+        cvss = false
+        cvss3 = true
+        risk = false
+        riskmatrix = false
+    elsif(report.scoring.downcase == "riskmatrix")
+        findings = Findings.all(:report_id => report.id, :order => [:risk.desc])
+        dread = false
+        cvss = false
+        cvss3 = false
+        risk = false
+        riskmatrix = true
+    else
+        findings = Findings.all(:report_id => report.id, :order => [:risk.desc])
+        dread = false
+        cvss = false
+        cvss3 = false
+        risk = true
+        riskmatrix = false
+    end
+
+    return findings,dread,cvss,cvss3,risk,riskmatrix
+end
+
+# Get the global configuration scoring algorithm and set at the report level
+def set_scoring(config_options)
+    if(config_options["dread"])
+    	return "dread"
+    elsif(config_options["cvss"])
+    	return "cvss"
+    elsif(config_options["cvssv3"])
+    	return "cvssv3"
+    elsif(config_options["riskmatrix"])
+    	return "riskmatrix"
+    end
+
+    return "risk"
+end

--- a/model/master.rb
+++ b/model/master.rb
@@ -347,6 +347,8 @@ class Reports
     property :owner, String, :length => 200
     property :authors, CommaSeparatedList, :required => false, :lazy => false
     property :user_defined_variables, String, :length => 10000
+    property :scoring, String, :length => 100
+
 
 end
 

--- a/routes/report.rb
+++ b/routes/report.rb
@@ -383,7 +383,7 @@ get '/report/:id/edit' do
         return "No Such Report"
     end
 
-    if @report.scoring == ""
+    unless @report.scoring
         @report.update(:scoring => set_scoring(config_options))
     end
 
@@ -509,7 +509,8 @@ get '/report/:id/findings' do
     if @report == nil
         return "No Such Report"
     end
-    if @report.scoring == ""
+
+    unless @report.scoring
         @report.update(:scoring => set_scoring(config_options))
     end
 
@@ -1064,7 +1065,7 @@ get '/report/:id/generate' do
         return "No Such Report"
     end
   
-    if @report.scoring == ""
+    unless @report.scoring
         @report.update(:scoring => set_scoring(config_options))
     end
 

--- a/routes/report.rb
+++ b/routes/report.rb
@@ -383,8 +383,9 @@ get '/report/:id/edit' do
         return "No Such Report"
     end
 
-    @report.scoring = set_scoring(config_options) if @report.scoring == ""
-    @report.update
+    if @report.scoring == ""
+        @report.update({"scoring" => set_scoring(config_options)})
+    end
 
     haml :report_edit, :encode_html => true
 end
@@ -508,8 +509,9 @@ get '/report/:id/findings' do
     if @report == nil
         return "No Such Report"
     end
-    @report.scoring = set_scoring(config_options) if @report.scoring == ""
-    @report.update
+    if @report.scoring == ""
+        @report.update({"scoring" => set_scoring(config_options)})
+    end
 
     @findings,@dread,@cvss,@cvssv3,@risk,@riskmatrix = get_scoring_findings(@report)
 
@@ -1061,8 +1063,10 @@ get '/report/:id/generate' do
     if @report == nil
         return "No Such Report"
     end
-    @report.scoring = set_scoring(config_options) if @report.scoring == ""
-    @report.update
+  
+    if @report.scoring == ""
+        @report.update({"scoring" => set_scoring(config_options)})
+    end
 
     user = User.first(:username => get_username)
 

--- a/routes/report.rb
+++ b/routes/report.rb
@@ -384,7 +384,7 @@ get '/report/:id/edit' do
     end
 
     if @report.scoring == ""
-        @report.update({"scoring" => set_scoring(config_options)})
+        @report.update(:scoring => set_scoring(config_options))
     end
 
     haml :report_edit, :encode_html => true
@@ -510,7 +510,7 @@ get '/report/:id/findings' do
         return "No Such Report"
     end
     if @report.scoring == ""
-        @report.update({"scoring" => set_scoring(config_options)})
+        @report.update(:scoring => set_scoring(config_options))
     end
 
     @findings,@dread,@cvss,@cvssv3,@risk,@riskmatrix = get_scoring_findings(@report)
@@ -1065,7 +1065,7 @@ get '/report/:id/generate' do
     end
   
     if @report.scoring == ""
-        @report.update({"scoring" => set_scoring(config_options)})
+        @report.update(:scoring => set_scoring(config_options))
     end
 
     user = User.first(:username => get_username)

--- a/views/report_edit.haml
+++ b/views/report_edit.haml
@@ -38,6 +38,16 @@
                       %option #{assessment_type}
             %tr
               %td{:style => 'width: 30%'}
+                Scoring Type
+              %td{:style => 'width: 70%'}
+                %select{ :name => "scoring" }
+                  - @risk_scores.each do |risk_score|
+                    - if risk_score.downcase == @report.scoring.downcase
+                      %option{ :selected => "selected" } #{risk_score}
+                    - else
+                      %option #{risk_score}
+            %tr
+              %td{:style => 'width: 30%'}
                 Full Company Name
               %td{:style => 'width: 70%'}
                 %input{:type => 'text', :style => 'width: 90%', :name => 'full_company_name', :value => "#{@report.full_company_name}"}


### PR DESCRIPTION
This PR allows scoring to be set at a report level. For users, they could host reports with different scoring algorithms. It also makes it easier to support only one template. 