### PR TITLE
Extending user defined data : User Defined Objects

### DIFF
--- a/helpers/helper.rb
+++ b/helpers/helper.rb
@@ -9,7 +9,7 @@ end
 
 def find_headers_footers(docx)
 	header_footer = []
-	
+
 	Zip::File.open(docx) do |zip|
 		i = 1
 		while zip.find_entry("word/header#{i}.xml") != nil do
@@ -165,12 +165,14 @@ def url_escape_hash(hash)
 end
 
 def meta_markup(text)
-	new_text = text.gsub("<paragraph>","&#x000A;").gsub("</paragraph>","")
-	new_text = new_text.gsub("<bullet>","*-").gsub("</bullet>","-*")
-	new_text = new_text.gsub("<h4>","[==").gsub("</h4>","==]")
-	new_text = new_text.gsub("<code>","[[[").gsub("</code>","]]]")
-	new_text = new_text.gsub("<indented>","[--").gsub("</indented>","--]")
-	new_text = new_text.gsub("<italics>","[~~").gsub("</italics>","~~]")
+		if not text == nil
+				new_text = text.gsub("<paragraph>","&#x000A;").gsub("</paragraph>","")
+				new_text = new_text.gsub("<bullet>","*-").gsub("</bullet>","-*")
+				new_text = new_text.gsub("<h4>","[==").gsub("</h4>","==]")
+				new_text = new_text.gsub("<code>","[[[").gsub("</code>","]]]")
+				new_text = new_text.gsub("<indented>","[--").gsub("</indented>","--]")
+				new_text = new_text.gsub("<italics>","[~~").gsub("</italics>","~~]")
+		end
 end
 
 
@@ -384,7 +386,7 @@ def cvss(data, is_cvssv3)
 		c2_vs += "A:N/"
 	elsif a == "partial"
 	    cvss_a = 0.275
-		c2_vs += "I:P/"	    
+		c2_vs += "I:P/"
 	else
 	    cvss_a = 0.660
 		c2_vs += "I:C/"
@@ -521,7 +523,7 @@ def cvss(data, is_cvssv3)
 	end
 
  	c3_vs = "CVSS3.0:/"
-	
+
 	# cvssV3
 	if is_cvssv3
 		attack_vector = data["attack_vector"].downcase
@@ -546,11 +548,11 @@ def cvss(data, is_cvssv3)
 		mod_confidentiality = data["mod_confidentiality"].downcase
 		mod_integrity = data["mod_integrity"].downcase
 		mod_availability = data["mod_availability"].downcase
- 
+
 	 	# Calculations taken from here:
 	 	# https://gist.github.com/TheCjw/23b1f8b8f1da6ceb011c
 	 	# https://www.first.org/cvss/specification-document#i8
-	 
+
 	 	#Base
 		if attack_vector == "network"
 			c3_vs += "AV:N/"
@@ -592,7 +594,7 @@ def cvss(data, is_cvssv3)
 	 			privileges_required_result = 0.62
 	 		end
 	 	end
-		
+
 		if user_interaction == "none"
 			c3_vs += "UI:N/"
 	 		user_interaction_result = 0.85
@@ -600,7 +602,7 @@ def cvss(data, is_cvssv3)
 			c3_vs += "UI:R/"
 	 		user_interaction_result = 0.62
 	 	end
-		
+
 		if scope_cvss == "unchanged"
 			c3_vs += "S:U/"
 	 		scope_cvss_result = 6.42
@@ -608,7 +610,7 @@ def cvss(data, is_cvssv3)
 			c3_vs += "S:C/"
 	 		scope_cvss_result = 7.52
 	 	end
-		
+
 	 	if confidentiality == "none"
 			c3_vs += "C:N/"
 	 		confidentiality_result = 0.0
@@ -733,7 +735,7 @@ def cvss(data, is_cvssv3)
 			c3_vs += "AR:L/"
 	 		availability_requirement_result = 0.5
 	 	end
-	 	
+
 		if mod_attack_vector == "network"
 			c3_vs += "MAV:N/"
 	 		mod_attack_vector_result = 0.85
@@ -750,7 +752,7 @@ def cvss(data, is_cvssv3)
 			c3_vs += "MAV:X/"
 	 		mod_attack_vector_result = attack_vector_result
 	 	end
-	 
+
 	 	if mod_attack_complexity == "high"
 			c3_vs += "MAC:H/"
 	 		mod_attack_complexity_result = 0.44
@@ -761,7 +763,7 @@ def cvss(data, is_cvssv3)
 			c3_vs += "MAC:X/"
 	 		mod_attack_complexity_result = attack_complexity_result
 	 	end
-		
+
 	 	if mod_privileges_required == "none"
 			c3_vs += "MPR:N/"
 	 		mod_privileges_required_result = 0.85
@@ -783,7 +785,7 @@ def cvss(data, is_cvssv3)
 			c3_vs += "MPR:X/"
 	 		mod_privileges_required_result = privileges_required_result
 	 	end
-		
+
 	 	if mod_user_interaction == "none"
 			c3_vs += "MUI:N/"
 	 		mod_user_interaction_result = 0.85
@@ -794,7 +796,7 @@ def cvss(data, is_cvssv3)
 			c3_vs += "MUI:X/"
 	 		mod_user_interaction_result = user_interaction_result
 	 	end
-		
+
 		if mod_scope == "unchanged"
 			c3_vs += "MS:U/"
 	 		mod_scope_result = 6.42
@@ -802,10 +804,10 @@ def cvss(data, is_cvssv3)
 			c3_vs += "MS:C/"
 	 		mod_scope_result = 7.52
 	 	elsif mod_scope == "not defined"
-	 		c3_vs += "MS:X/"	 		
+	 		c3_vs += "MS:X/"
 	 		mod_scope_result = scope_cvss_result
 	 	end
-		
+
 		if mod_confidentiality == "none"
 			c3_vs += "MC:N/"
 	 		mod_confidentiality_result = 0.0
@@ -851,7 +853,7 @@ def cvss(data, is_cvssv3)
 		# Base Score
 	 	cvss_exploitability = 8.22 * attack_vector_result * attack_complexity_result * privileges_required_result * user_interaction_result #exploitabilitySubScore
 	 	cvss_impact_multipler = (1 - ((1 - confidentiality_result) * (1 - integrity_result) * (1 - availability_result))) # ISCbase
-	 	
+
 	 	if scope_cvss == "unchanged"
 	 		cvss_impact_score = scope_cvss_result * cvss_impact_multipler
 	 	elsif scope_cvss == "changed"
@@ -867,7 +869,7 @@ def cvss(data, is_cvssv3)
 	 			cvss_base_score = (((cvss_exploitability + cvss_impact_score) * 10).ceil) / 10.0
 	 		else
 	 			cvss_base_score = 10
-	 		end	
+	 		end
 		elsif scope_cvss == "changed"
 			if ((cvss_exploitability + cvss_impact_score) * 1.08) < 10
 				cvss_base_score = ((((cvss_exploitability + cvss_impact_score) * 1.08) * 10).ceil) / 10.0
@@ -882,7 +884,7 @@ def cvss(data, is_cvssv3)
 
 		# Enviromental Score
 	 	cvss_mod_exploitability = 8.22 * mod_attack_vector_result * mod_attack_complexity_result * mod_privileges_required_result * mod_user_interaction_result
-	 
+
 	 	if (1 - (1 - mod_confidentiality_result * confidentiality_requirement_result) * (1 - mod_integrity_result * integrity_requirement_result) * (1 - mod_availability_result * availability_requirement_result)) > 0.915
 	 		cvss_mod_impact_multipler = 0.915
 	 	end
@@ -901,9 +903,9 @@ def cvss(data, is_cvssv3)
 	 			cvss_mod_impact_score = scope_cvss_result * (cvss_mod_impact_multipler - 0.029) - 3.25 * ((cvss_mod_impact_multipler - 0.02) ** 15)
 	 		end
 	 	end
-	 
+
 	 	mod_impact_exploit_add = cvss_mod_impact_score + cvss_mod_exploitability
-	 
+
 	 	if cvss_mod_impact_score <= 0
 	 		cvss_environmental = 0
 	 	else
@@ -951,9 +953,9 @@ def cvss(data, is_cvssv3)
 
 	if(is_cvssv3)
 		data["cvss_base_score"] = sprintf("%0.1f" % cvss_base_score)
- 		data["cvss_impact_score"] = sprintf("%0.1f" % cvss_impact_score)	
+ 		data["cvss_impact_score"] = sprintf("%0.1f" % cvss_impact_score)
 		data["cvss_mod_impact_score"] = sprintf("%0.1f" % cvss_mod_impact_score)
-	
+
 	 	data["cvss_total"] = sprintf("%0.1f" % cvss_environmental)
 	else
 		data["cvss_total"] = sprintf("%0.1f" % cvss_total)

--- a/model/master.rb
+++ b/model/master.rb
@@ -51,7 +51,7 @@ class TemplateFindings
     property :cvss_total, Float, :required => false
     property :ease, String, :required => false
     property :c2_vs, String, :length => 300, :required => false
-    
+
     #CVSSv3
     property :attack_vector, String, :required => false
     property :attack_complexity, String, :required => false
@@ -364,12 +364,42 @@ class Attachments
 
 end
 
+class Charts
+    include DataMapper::Resource
+
+    property :id, Serial
+    property :location, String, :length => 400
+    property :report_id, String, :length => 30
+    property :type, String, :length => 500
+
+end
+
 class Hosts
     include DataMapper::Resource
 
     property :id, Serial
     property :ip, String
     property :port, String
+
+end
+
+class UserDefinedObjectTemplates
+    include DataMapper::Resource
+
+    property :id, Serial
+    property :type, String, :length => 300
+    property :udo_properties, String, :length => 10000
+
+end
+
+class UserDefinedObjects
+    include DataMapper::Resource
+
+    property :id, Serial
+    property :report_id, Integer, :required => true
+    property :template_id, Integer, :required => true
+    property :type, String, :length => 300
+    property :udo_properties, String, :length => 10000
 
 end
 
@@ -383,10 +413,10 @@ class Xslt
     property :report_type, String, :length => 400
     property :finding_template, Boolean, :required => false, :default => false
     property :status_template, Boolean, :required => false, :default => false
-	
+
     has n, :components, 'Xslt_component',
-        :parent_key => [ :id ], 
-        :child_key  => [ :xslt_id ] 
+        :parent_key => [ :id ],
+        :child_key  => [ :xslt_id ]
 end
 
 class Xslt_component
@@ -395,11 +425,11 @@ class Xslt_component
     property :id, Serial
     property :xslt_location, String, :length => 400
     property :name, String, :length => 400
-	
-    belongs_to :xslt, 'Xslt',
-        :parent_key => [ :id ],
-        :child_key  => [ :xslt_id ],
-	:required   => true
+
+  	belongs_to :xslt, 'Xslt',
+      	:parent_key => [ :id ],
+    		:child_key  => [ :xslt_id ],
+    		:required   => true
 end
 
 DataMapper.finalize

--- a/routes/admin.rb
+++ b/routes/admin.rb
@@ -252,7 +252,7 @@ post '/admin/config' do
     elsif params["risk_scoring"] == "RISKMATRIX"
     	config_options["dread"] = false
         config_options["cvss"] = false
-        config_options["cvssv3"] = false  
+        config_options["cvssv3"] = false
         config_options["riskmatrix"] = true
     else
         config_options["dread"] = false
@@ -482,7 +482,7 @@ post '/admin/templates/add' do
 			File.open(componentHash['xslt_location'], 'wb') {|f| f.write(component_xslt) }
 			list_components_files.push(componentHash)
 		end
-		
+
 		# insert components into the db
 		list_components_files.each do |component|
 			@component = Xslt_component.new(component)
@@ -570,7 +570,7 @@ post '/admin/templates/edit' do
 			File.open(componentHash['xslt_location'], 'wb') {|f| f.write(component_xslt) }
 			list_components_files.push(componentHash)
 		end
-		
+
 		# insert components into the db
 		list_components_files.each do |component|
 			@component = Xslt_component.new(component)
@@ -597,3 +597,99 @@ get '/admin/admin_plugins' do
     haml :enabled_plugins, :encode_html => true
 end
 
+get '/admin/udo_templates' do
+    redirect to("/no_access") unless is_administrator?
+
+# delete UDO template part
+    if params[:delete]
+        udo_template = UserDefinedObjectTemplates.get(params[:delete])
+        if udo_template == nil
+            return "UDO Template not found"
+        end
+        udo_template.destroy
+    end
+    @udos_templates = UserDefinedObjectTemplates.all
+    haml :user_defined_object_templates, :encode_html => true
+end
+
+post '/admin/udo_templates' do
+    redirect to("/no_access") unless is_administrator?
+    data = url_escape_hash(request.POST)
+
+# Save new UDO template part
+    if data["action"] = "Save"
+        new_udo_template = UserDefinedObjectTemplates.new
+        new_udo_template.type = data["object_type"]
+        udo_properties = {}
+        #we extract the udo properties from the posted data
+        data.each do |param, value|
+            if param =~ /property_/
+                if not value.to_s.empty?
+                    udo_properties[value] = ""
+                end
+            end
+        end
+        new_udo_template.udo_properties = udo_properties.to_json
+        new_udo_template.save()
+    end
+
+    @udos_templates = UserDefinedObjectTemplates.all
+
+    haml :user_defined_object_templates, :encode_html => true
+end
+
+#edit udo template
+get '/admin/udo_template/:template_id/edit' do
+    redirect to("/no_access") unless is_administrator?
+    @udo_to_edit = UserDefinedObjectTemplates.get(params[:template_id])
+    if @udo_to_edit == nil
+        return "No such UDO Template"
+    end
+    @udo_to_edit_properties = JSON.parse(@udo_to_edit.udo_properties)
+    haml :udo_template_edit, :encode_html => true
+end
+
+post '/admin/udo_template/:template_id/edit' do
+    redirect to("/no_access") unless is_administrator?
+    data = url_escape_hash(request.POST)
+    @udo_to_edit = UserDefinedObjectTemplates.get(params[:template_id])
+    if @udo_to_edit == nil
+        return "No such UDO Template"
+    end
+    @udo_to_edit_properties = JSON.parse(@udo_to_edit.udo_properties)
+
+
+    udo_properties = {}
+    #we extract the udo properties from the posted data
+    data.each do |param1, value1|
+        if not value1.to_s.empty?
+            #we add the new properties
+            if param1 =~ /prop_new_\d+/
+                id = param1.split("_")[2]
+                data.each do |param2, value2|
+                    if param2 =~ /default_new_#{id}/
+                        if not value2 =~ /\<paragraph\>/
+                            udo_properties[value1] = "<paragraph>#{value2}</paragraph>"
+                        else
+                            udo_properties[value1] = value2
+                        end
+                    end
+                end
+            #we edit the already existing properties
+            elsif param1 =~ /prop_/
+                data.each do |param2, value2|
+                    if param2 =~ /default_#{param1.split("_")[-1]}/
+                        if not value2 =~ /\<paragraph\>/
+                            udo_properties[value1] = "<paragraph>#{value2}</paragraph>"
+                        else
+                            udo_properties[value1] = value2
+                        end
+                    end
+                end
+            end
+        end
+    end
+    @udo_to_edit.udo_properties = udo_properties.to_json
+    @udo_to_edit.save()
+    redirect to("/admin/udo_templates")
+end

--- a/views/additional_features.haml
+++ b/views/additional_features.haml
@@ -4,7 +4,10 @@
   %table
     %tr
       %td
-        %a{ :href => "/report/#{@report.id}/user_defined_variables"} Edit User Defined Variables
+        %a{ :href => "/report/#{@report.id}/user_defined_variables"} Manage User Defined Variables
+    %tr
+      %td
+        %a{ :href => "/report/#{@report.id}/udo/manage"} Manage User Defined Objects
     %tr
       %td
         %a{ :href => "/report/#{@report.id}/export" } Export Current Report (Warning: Attachments must be exported separately)
@@ -52,4 +55,4 @@
         %a{ :href => "/report/#{@report.id}/presentation?print-pdf" } Generate Presentation to PDF (NOTE: Print and Save to PDF to view)
     %tr
       %td
-        %a{ :href => "/report/#{@report.id}/presentation_export" } Export Presentation to HTML 
+        %a{ :href => "/report/#{@report.id}/presentation_export" } Export Presentation to HTML

--- a/views/layout.haml
+++ b/views/layout.haml
@@ -99,6 +99,8 @@
                   %a{ :href => '/admin/templates/add' } Add Report Template
                 %li
                   %a{ :href => '/admin/templates' } List Report Templates
+                %li
+                  %a{ :href => '/admin/udo_templates' } Manage UDOs templates for reports
                 %li.nav-header Plugin Menu
                 %li
                   %a{ :href => '/admin/plugins' } Enable/Disable Plugins

--- a/views/udo_template_edit.haml
+++ b/views/udo_template_edit.haml
@@ -1,0 +1,77 @@
+%link{:href => "/css/bootstrap-suggest.css", :rel => "stylesheet"}/
+%link{:href => "/css/dynamic-fields.css", :rel => "stylesheet"}/
+%script{:src => "/js/bootstrap-suggest.js"}
+
+%br
+%br
+.span10
+  %h3 Editing object " #{@udo_to_edit.type} "
+  %br
+  %hr
+  %h4 Existing properties
+  %br
+  %form{ :class => "form-horizontal", :method => 'post', :enctype => 'application/x-www-form-urlencoded'}
+    - @udo_to_edit_properties.each do |param_name, value|
+      .control-group
+        %label{ :class => "control-label", :for => "Property-Name" } Property Name
+        .controls
+          %input{:value => "#{param_name}", :name => "prop_#{param_name}"}
+      .control-group
+        %label{ :class => "control-label", :for => "Default-Value" } Default Value
+        .controls
+          %textarea{:name => "default_#{param_name}",:rows => '3', :class => 'allowMarkupShortcut input-large'}
+            #{meta_markup(value)}
+    %hr
+    %h4 Add properties
+    %br
+    %div{"data-role" => "dynamic-fields"}
+      .form-inline
+        .control-group
+          %label.control-label{:for => "New-Property-Name"} New Property Name
+          .controls
+            %input#field-name.form-control{:type => "text", :name => "prop_new_1"}/
+        .control-group
+          %label{ :class => "control-label", :for => "Default-Value" } Default Value
+          .controls
+            %textarea{:name => "default_new_1",:rows => '3', :class => 'allowMarkupShortcut input-large'}
+        %button.btn.btn-danger{"data-role" => "remove"}
+          %span.icon-minus
+        %button.btn.btn-info{"data-role" => "add"}
+          %span.icon-plus
+
+    %br
+    %hr
+    %input{:type => 'submit', :value => 'Edit', :name => 'action',:class => "btn" }
+
+:javascript
+  $(function() {
+      // Remove button click
+      $(document).on(
+          'click',
+          '[data-role="dynamic-fields"] > .form-inline [data-role="remove"]',
+          function(e) {
+              e.preventDefault();
+              $(this).closest('.form-inline').remove();
+          }
+      );
+      // Add button click
+      $(document).on(
+          'click',
+          '[data-role="dynamic-fields"] > .form-inline [data-role="add"]',
+          function(e) {
+              e.preventDefault();
+              var container = $(this).closest('[data-role="dynamic-fields"]');
+              new_field_group = container.children().filter('.form-inline:first-child').clone();
+              var i = 2;
+              new_field_group.find('input').each(function(){
+                  $(this).attr('name','prop_new_'+i)
+                  $(this).val('')
+              });
+              new_field_group.find('textarea').each(function(){
+                  $(this).attr('name','default_new_'+i)
+                  $(this).val('')
+              });
+              container.append(new_field_group);
+          }
+      );
+  });

--- a/views/user_defined_object_create.haml
+++ b/views/user_defined_object_create.haml
@@ -1,0 +1,19 @@
+%link{:href => "/css/bootstrap-suggest.css", :rel => "stylesheet"}/
+%script{:src => "/js/bootstrap-suggest.js"}
+
+%br
+%br
+.span10
+  %h3 Create new #{@udo_template.type}
+  %hr
+  %form{ :method => 'post', :enctype => 'application/x-www-form-urlencoded'}
+    - @udo_template_properties.each do |param_name, param_default_value|
+      .control-group
+        %label{ :class => "control-label", :for => "#{param_name}" }
+          %strong
+            #{param_name}
+        .controls
+          %textarea{ :type => 'textarea', :name => "param_#{param_name}",:rows => '2', :class => 'allowMarkupShortcut input-large'}
+            #{meta_markup(param_default_value)}
+    %br
+    %input{:type => 'submit', :value => 'Save', :name => 'action',:class => "btn" }

--- a/views/user_defined_object_edit.haml
+++ b/views/user_defined_object_edit.haml
@@ -1,0 +1,19 @@
+%link{:href => "/css/bootstrap-suggest.css", :rel => "stylesheet"}/
+%script{:src => "/js/bootstrap-suggest.js"}
+
+%br
+%br
+.span10
+  %h3 Edit #{@udo_to_edit.type} object
+  %hr
+  %form{ :method => 'post', :enctype => 'application/x-www-form-urlencoded'}
+    - @udo_to_edit_properties.each do |param_name, value|
+      .control-group
+        %label{ :class => "control-label", :for => "#{param_name}" }
+          %strong
+            #{param_name}
+        .controls
+          %textarea{:name => "param_#{param_name}",:rows => '2', :class => 'allowMarkupShortcut input-large'}
+            #{meta_markup(value)}
+    %br
+    %input{:type => 'submit', :value => 'Save', :name => 'action',:class => "btn" }

--- a/views/user_defined_object_manage.haml
+++ b/views/user_defined_object_manage.haml
@@ -1,0 +1,91 @@
+%br
+%br
+.span10
+  .control-group
+    %label{ :class => "control-label", :for => "overview" }
+      %a{:href=> '#modaloverview', "data-toggle"=>'modal', :class=>'btn btn-info'}
+        UDOs Overview
+    .modal{:id=>'modaloverview', :class=>'modal hide fade', :tabindex=>'-1', :role=>'dialog', "aria-labelledby"=>'modal-label', "aria-hidden"=>'true'}
+      .modal-header
+        %button{:type=>'button', :class=>'close', "data-dismiss"=>"modal", "aria-hidden"=>"true"}
+          x
+        %h3{:id=>"modal-label"}
+          User Defined Objects
+      .modal-body
+        %p
+          An User Defined Object can be anything that is usually tied to more than one information : contact (mail, name, role...), applications (URL, IP, Name...).
+        %p
+          User Defined Objects, once created, can be used in your templates with all meta characters. For this, the following path should be used:
+        %p /root/udo/&lt&ltobject name&gt&gt/&lt&ltproperty name&gt&gt.
+        %p
+          For exemple, if you have an object <b>Application</b> with the properties <b>IP</b> and <b>URL</b>, you could do the following:
+          %div{:style => "background-color:#F2F3F4"}
+            %p
+              ¬report/udo/application¬
+            %p
+              IP : πIPπ
+            %p
+              URL : πURLπ
+            %p
+              ∆
+          %p
+            %br
+            This would print in your report all the IP and URL of the created applications.
+          %p
+            %strong
+              If you put a space in your properties, they will be replaced by an underscore in the corresponding path
+          %p
+            %strong
+              Meta markup is support by UDOs
+  %br
+  - if @udo_template_created
+    %h3 New #{@udo_template_created.type} object created !
+    %br
+    %br
+  - if not @udos_templates.empty?
+    - @udos_templates.each do |udo_template|
+      - i = 1
+      %hr
+      %h4
+        #{udo_template.type}
+        %a{ :class => "btn btn-info btn-small", :href => "/report/#{@id}/udo/#{udo_template.id}/create"}
+          %i{:class => 'icon-plus icon-white', :title => "Create new #{udo_template.type}"}
+      - udos_linked_to_current_template = UserDefinedObjects.all(:template_id => udo_template.id, :report_id => @id)
+      - if not udos_linked_to_current_template.empty?
+        .table.table-striped
+          %table{:style => "white-space: nowrap; table-layout: fixed"}
+            %tr
+              %td
+                %strong
+                  N°
+              - template_properties = JSON.parse(udo_template.udo_properties)
+              - template_properties.each do |property_name, property_default_value|
+                %td
+                  %strong
+                    %i
+                      #{property_name}
+              %td
+                %strong
+                  Actions
+            - udos_linked_to_current_template.each do |udo|
+              %tr
+                %td
+                  #{i}
+                - i += 1
+                - properties = JSON.parse(udo.udo_properties)
+                - template_properties.each do |template_property_name, template_property_value|
+                  %td{:style => "overflow:hidden;text-overflow:ellipsis;max-width: 300px;"}
+                    #{meta_markup(properties[template_property_name.downcase])}
+                %td
+                  %a{ :class => "btn btn-danger btn-small", :href => "/report/#{@id}/udo/#{udo.id}/delete"}
+                    %i{:class => 'icon-remove icon-white', :title => "Delete this #{udo_template.type.downcase}"}
+                  %a{ :class => "btn btn-warning btn-small", :href => "/report/#{@id}/udo/#{udo.id}/edit"}
+                    %i{:class => 'icon-pencil icon-white', :title => "Edit this #{udo_template.type.downcase}"}
+      - else
+        You have no #{udo_template.type.downcase} yet !
+        %br
+        %br
+      %br
+  - else
+    %h4
+      No UDO Template. Ask your administrator to create the UDO templates you want to use in your report.

--- a/views/user_defined_object_templates.haml
+++ b/views/user_defined_object_templates.haml
@@ -1,0 +1,90 @@
+.span10
+  %br
+  %br
+  - if @udos_templates.empty?
+    %h3
+      It appears you do not have any user defined objects. Would you like to add some?
+    %br
+  - else
+    %hr
+    %h3
+      User Defined Object template list :
+    %br
+      - @udos_templates.each do |udo|
+        %br
+        %div{ :class => 'w3-padding'}
+          %table.table-striped{ :class => 'padding'}
+            %tr
+              %td
+                %strong
+                  %i
+                    #{udo.type}
+              - udo_properties = JSON.parse(udo.udo_properties)
+              - udo_properties.each do |key, value|
+                %td
+                  #{key}
+              %td
+                %a{ :class => "btn btn-danger btn-sm", :href => "/admin/udo_templates?delete=#{udo.id}"}
+                  %i{:class => 'icon-remove icon-white', :title => "Delete #{udo.type.downcase} template"}
+                %a{ :class => "btn btn-warning btn-sm", :href => "/admin/udo_template/#{udo.id}/edit"}
+                  %i{:class => 'icon-pencil icon-white', :title => "Edit #{udo.type.downcase} template"}
+
+  %hr
+  %h3
+    Add an User Defined Object template :
+  %br
+    #fields.control-group
+      %label.control-label{:for => "field1"}
+      #profs.controls
+        %form.input-append{:method => 'post'}
+          #field
+            .table.table-striped
+              %table
+                %tr
+                  %td
+                    Object Type:&nbsp;
+                  %td
+                    %input{:type => 'text', :style => 'width: 90%', :id => 'object_name', :name =>'object_type', :placeholder => "Object Type", :required => "true"}
+                %tr
+                  %td
+                    Object Properties Names:&nbsp;
+                  %td
+                    %input#field1.input{:autocomplete => "off", "data-items" => "8", :name => "property_1", :placeholder => "Property Name 1", :type => "text", :required => "true"}/
+                    %button#b1.btn.add-more{:type => "button"} +
+          %input{:type => 'submit', :value => 'Save', :name => 'action',:class => "btn" }
+
+
+
+:javascript
+  $(document).ready(function(){
+      var next = 1;
+      $(".add-more").click(function(e){
+          e.preventDefault();
+          var addto = "#field" + next;
+          var addRemove = "#field" + (next);
+          next = next + 1;
+          var newIn = '<input autocomplete="off" placeholder="Property Name '+ next +'" class="input form-control" id="field' + next + '" name="property_' + next + '" type="text">';
+          var newInput = $(newIn);
+          var removeBtn = '<button id="remove' + (next - 1) + '" class="btn btn-danger remove-me" >-</button></div><div id="field">';
+          var removeButton = $(removeBtn);
+          $(addto).after(newInput);
+          $(addRemove).after(removeButton);
+          $("#field" + next).attr('data-source',$(addto).attr('data-source'));
+          $("#count").val(next);
+
+              $('.remove-me').click(function(e){
+                  e.preventDefault();
+                  var fieldNum = this.id.charAt(this.id.length-1);
+                  var fieldID = "#field" + fieldNum;
+                  $(this).remove();
+                  $(fieldID).remove();
+              });
+      });
+  });
+
+:plain
+  <style>
+    .padding>tbody>tr>td, .mytable>tbody>tr>th, .mytable>tfoot>tr>td, .mytable>tfoot>tr>th, .mytable>thead>tr>td, .mytable>thead>tr>th {
+        padding: 8px;
+    }
+  </style>


### PR DESCRIPTION
Serpico is a really powerful tool, yet there was some use cases that I felt were quite painful to manage.

For exemple, there is no way to fill multiple client contacts. You could create a ton of udvs, and name them for exemple : 

```
Client_Name_1, Client_Name_2, Client_Name_3, CLient_Name_4
Client_Mail_1, CLient_Mail_2, CLient_Mail_2, Client_Mail_3, Client_Mail_4
Client_Phone_1,Client_Phone_2,Client_phone_3,Client_Phone_4
```
And so on...

But this is really cumbersome for multiple reasons :

- What if I have only one contact ? The other variable will pollute my view for nothing
- What if I have a fifth conctact ? I will have to add X new UDV (where X is the number of information tied to a contact)
- I can't use the ∞ metacharacter to make a table out of those UDVs
- Not only that, but I can't loop through the contacts at all

This state of fact is also true for a lot of other things : for exemple application met in an external pentest, phishing campains, etc.

Which lead us to the reason for this PR 

**Introducing User Defined Objects to Serpico**

User Defined Objects build on the principle of User Defined Variable. UDOs are used to create object that are usually tied to multiple informations (contacts, web applications, hosts...)

Process for creating an UDO:

- An admin create the UDO template

![image](https://user-images.githubusercontent.com/3451172/29925866-f64a2a84-8e61-11e7-9cb4-2d342e9d53a5.png)

- The user can know create UDO from this template, for a given report

![image](https://user-images.githubusercontent.com/3451172/29926002-6845ab54-8e62-11e7-8c92-29d8ed7da310.png)

- Those applications can now be imported in the template

![image](https://user-images.githubusercontent.com/3451172/29926481-e9c8699a-8e63-11e7-8905-9e83aea7ad47.png)

![image](https://user-images.githubusercontent.com/3451172/29926525-f72f4662-8e63-11e7-8d3a-3cc55f142862.png)









