### PR TITLE
New logging setup

### DIFF
--- a/helpers/helper.rb
+++ b/helpers/helper.rb
@@ -1,6 +1,30 @@
 require 'rubygems'
 require 'zip'
 
+# Log a message including the user and the time
+def serpico_log(msg)
+	user = User.first(:username => get_username)
+	if user
+		uname = user.username
+	else
+		uname = "unknown user"
+	end
+	if settings.logger_out
+		settings.logger_out.puts "|+| [#{DateTime.now.strftime("%d/%m/%Y %H:%M")}] #{msg} : #{uname}"
+	else
+		puts "|+| [#{DateTime.now.strftime("%d/%m/%Y %H:%M")}] #{msg} : #{uname}"
+	end	
+end
+
+# Log a message globally, not attached to a user
+def server_log(msg)
+	if settings and settings.logger_out
+		settings.logger_out.puts "|+| [#{DateTime.now.strftime("%d/%m/%Y %H:%M")}] #{msg} : SERVER_LOG"
+	else
+		puts "|+| [#{DateTime.now.strftime("%d/%m/%Y %H:%M")}] #{msg} : SERVER_LOG"
+	end	
+end
+
 def docx_modify(rand_file,docx_xml,fil_r)
 	Zip::File.open(rand_file) do |zipfile|
 	  zipfile.get_output_stream(fil_r) {|f| f.write(docx_xml)}

--- a/routes/admin.rb
+++ b/routes/admin.rb
@@ -89,6 +89,7 @@ post '/admin/add_user' do
         user.save
     end
 
+    serpico_log("User #{user.username} created")
     redirect to('/admin/list_user')
 end
 
@@ -114,6 +115,8 @@ get '/admin/delete/:id' do
 
     @user = User.first(:id => params[:id])
     @user.destroy if @user
+
+    serpico_log("User #{@user.username} deleted")
 
     redirect to('/admin/list_user')
 end

--- a/routes/report.rb
+++ b/routes/report.rb
@@ -365,6 +365,8 @@ get '/report/:id/remove' do
     @findings.destroy
     @report.destroy
 
+    serpico_log("Report deleted, Report #{id}")
+
     redirect to("/reports/list")
 end
 
@@ -850,7 +852,8 @@ post '/report/:id/findings_add' do
         end
         finding.save
     end
-
+    
+    serpico_log("#{@newfinding.title} added to report #{id}")
 
     @findings,@dread,@cvss,@cvssv3,@risk,@riskmatrix = get_scoring_findings(@report)
 
@@ -1104,6 +1107,7 @@ get '/report/:id/findings/:finding_id/remove' do
 
     # Update the finding with templated finding stuff
     @finding.destroy
+    serpico_log("#{@finding.title} deleted from report #{id}")
 
     redirect to("/report/#{id}/findings")
 end
@@ -1380,8 +1384,6 @@ get '/report/:id/generate' do
 	end
     ### IMAGE INSERT CODE
     if docx_xml.to_s =~ /\[!!/
-        puts "|+| Trying to insert image --- "
-
         # first we read in the current [Content_Types.xml]
         content_types = read_rels(rand_file,"[Content_Types].xml")
 
@@ -1431,6 +1433,8 @@ get '/report/:id/generate' do
 	list_components.each do |name, xml|
 		docx_modify(rand_file, xml.to_s,name)
 	end
+
+    serpico_log("Report generation attempted, Report Name: #{@report.report_name} #{rand_file} #{xslt_elem.xslt_location}")
     send_file rand_file, :type => 'docx', :filename => "#{@report.report_name}.docx"
 end
 
@@ -1501,7 +1505,7 @@ post '/report/import' do
     if line["Attachments"]
         # now add the attachments
         line["Attachments"].each do |attach|
-            puts "importing attachments"
+            serpico_log("Importing attachments to #{f.id}")
             attach["id"] = nil
 
             attach["filename"] = "Unknown" if attach["filename"] == nil

--- a/serpico.rb
+++ b/serpico.rb
@@ -2,7 +2,6 @@ require "bundler/setup"
 require 'webrick/https'
 require 'openssl'
 require 'json'
-
 require "./server.rb"
 config_options = JSON.parse(File.read('./config.json'))
 
@@ -15,8 +14,15 @@ bind_address =  config_options["bind_address"]
 
 server_options = {
     :Port => port,
-    :BindAddress => bind_address
+    :BindAddress => bind_address,
 }
+
+if config_options["show_exceptions"].to_s.downcase == "false" or (not config_options["show_exceptions"])
+    puts "|+| [#{DateTime.now.strftime("%d/%m/%Y %H:%M")}] Sending Webrick logging to /dev/null.."
+    server_options[:Logger] = WEBrick::Log.new(File.open(File::NULL, 'w'))
+    server_options[:AccessLog] = []
+end
+
 
 if (use_ssl) then
     certificate_content = File.open(ssl_certificate).read


### PR DESCRIPTION
Logging in Serpico produces way too many messages of low value by default. This new PR silences all logging around requests and defaults to only logging initiated by the tool. 

It introduces two new methods:

## serpico_log
```
serpico_log(msg)
```
which can be used to log an action performed by a user. By defaults it adds a the DateTime of the action and the user that performed the action
```
serpico_log("User willis deleted")
writes
|+| [01/09/2017 20:18] User willis deleted : administrator
```

## server_log
```
server_log(msg)
```
which can be used to log a message performed by the server (e.g. unauthenticated)
```
serpico_log("Service started")
writes
|+| [01/09/2017 20:18] Service started : SERVER_LOG
```

As per [Issue 319](https://github.com/SerpicoProject/Serpico/issues/319) the following has been added:
- Finding is added/deleted
- Report is generated/deleted
- User is created/deleted

