### PR TITLE
add screenshot metacharacter

### DIFF
--- a/helpers/xslt_generation.rb
+++ b/helpers/xslt_generation.rb
@@ -566,6 +566,32 @@ def generate_xslt(docx)
 		document = document.sub('∆',"</w:t></w:r></w:p>#{end_ifs}</xsl:for-each><w:p><w:r><w:t>")
 	end
 
+###############################
+# ツ - Placeholder for image
+
+	replace = document.split('ツ')
+
+	if (((replace.size-1) % 2) != 0)
+        raise ReportingError.new("Uneven number of ツ. This is usually caused by a mismatch in a variable.")
+	end
+
+	count = 0
+	replace.each do |omega|
+		if (count % 2) == 0
+			count = count + 1
+			next
+		end
+
+		# Execute when between two ツ
+		omega = compress(omega)
+
+		replace[count]="[!!#{omega.downcase}!!]"
+
+		count = count + 1
+	end
+
+	# remove all the ツ and put the document back together
+	document = replace.join("")
 
 
 
@@ -607,21 +633,21 @@ def generate_xslt_components(docx)
 	debug = false
 
 	list_components_xslt = {}
-	
+
 	#add line breaks for easier reading, only use with debugging
 	#document = document.gsub('>',">\n")
 
 	components = find_headers_footers(docx)
-	
+
 	components.each do |component|
 		document = read_rels(docx,component)
-		
+
 		# replace {} for the sake of XSL
 		document = document.gsub("{","{{").gsub("}","}}")
-		
+
 		# add in xslt header
 		document = @top + document
-		
+
 		# Ω - used as a normal substituion variable
 		# let's pull out variables
 		replace = document.split('Ω')
@@ -636,7 +662,7 @@ def generate_xslt_components(docx)
 				count = count + 1
 				next
 			end
-				
+
 			# Execute when between two Ω
 			omega = compress(omega)
 
@@ -688,7 +714,7 @@ def generate_xslt_components(docx)
 
 		# add in xslt footer
 		document = document + @bottom
-		
+
 		list_components_xslt[component] = document
 	end
 

--- a/model/master.rb
+++ b/model/master.rb
@@ -413,7 +413,7 @@ class Xslt
     property :report_type, String, :length => 400
     property :finding_template, Boolean, :required => false, :default => false
     property :status_template, Boolean, :required => false, :default => false
-
+    property :screenshot_names, String, :length => 10000
     has n, :components, 'Xslt_component',
         :parent_key => [ :id ],
         :child_key  => [ :xslt_id ]

--- a/routes/admin.rb
+++ b/routes/admin.rb
@@ -429,23 +429,23 @@ post '/admin/templates/add' do
 
     @admin = true
 
-	xslt_file = "./templates/#{rand(36**36).to_s(36)}.xslt"
+    xslt_file = "./templates/#{rand(36**36).to_s(36)}.xslt"
 
     redirect to("/admin/templates/add") unless params[:file]
 
-	# reject if the file is above a certain limit
-	if params[:file][:tempfile].size > 100000000
-		return "File too large. 10MB limit"
-	end
+    # reject if the file is above a certain limit
+    if params[:file][:tempfile].size > 100000000
+        return "File too large. 10MB limit"
+    end
 
-	docx = "./templates/#{rand(36**36).to_s(36)}.docx"
-	File.open(docx, 'wb') {|f| f.write(params[:file][:tempfile].read) }
+    docx = "./templates/#{rand(36**36).to_s(36)}.docx"
+    File.open(docx, 'wb') {|f| f.write(params[:file][:tempfile].read) }
 
     error = false
     detail = ""
     begin
-	    xslt = generate_xslt(docx)
-		xslt_components = generate_xslt_components(docx)
+        xslt = generate_xslt(docx)
+        xslt_components = generate_xslt_components(docx)
     rescue ReportingError => detail
         error = true
     end
@@ -455,17 +455,17 @@ post '/admin/templates/add' do
         "The report template you uploaded threw an error when parsing:<p><p> #{detail.errorString}"
     else
 
-    	# open up a file handle and write the attachment
-	    File.open(xslt_file, 'wb') {|f| f.write(xslt) }
+      # open up a file handle and write the attachment
+      File.open(xslt_file, 'wb') {|f| f.write(xslt) }
       #extract the screenshot names from the file
       screenshot_names = xslt.scan(/\[!!(.*?)!!]/)
-	    # delete the file data from the attachment
-	    datax = Hash.new
-	    # to prevent traversal we hardcode this
-	    datax["docx_location"] = "#{docx}"
-	    datax["xslt_location"] = "#{xslt_file}"
-	    datax["description"] = 	params[:description]
-	    datax["report_type"] = params[:report_type]
+      # delete the file data from the attachment
+      datax = Hash.new
+      # to prevent traversal we hardcode this
+      datax["docx_location"] = "#{docx}"
+      datax["xslt_location"] = "#{xslt_file}"
+      datax["description"] = 	params[:description]
+      datax["report_type"] = params[:report_type]
       datax["screenshot_names"] = screenshot_names.join(",")
       data = url_escape_hash(datax)
       data["finding_template"] = params[:finding_template] ? true : false
@@ -475,32 +475,32 @@ post '/admin/templates/add' do
 
       if @template
           @template.update(:xslt_location => data["xslt_location"], :docx_location => data["docx_location"], :description => data["description"], :screenshot_names => data["screenshot_names"])
-			@template.components.destroy
-	    else
-		    @template = Xslt.new(data)
-		    @template.save
-	    end
+	  @template.components.destroy
+      else
+          @template = Xslt.new(data)
+          @template.save
+      end
 
-		# create a xslt file for each component
-		list_components_files = []
-		xslt_components.each do |component_name, component_xslt|
-			componentHash = Hash.new
-			componentHash['xslt_location'] = "./templates/#{rand(36**36).to_s(36)}.xslt"
-			componentHash['name'] = component_name
-			componentHash['xslt'] = @template
-			File.open(componentHash['xslt_location'], 'wb') {|f| f.write(component_xslt) }
-			list_components_files.push(componentHash)
-		end
+      # create a xslt file for each component
+      list_components_files = []
+      xslt_components.each do |component_name, component_xslt|
+          componentHash = Hash.new
+          componentHash['xslt_location'] = "./templates/#{rand(36**36).to_s(36)}.xslt"
+          componentHash['name'] = component_name
+          componentHash['xslt'] = @template
+          File.open(componentHash['xslt_location'], 'wb') {|f| f.write(component_xslt) }
+          list_components_files.push(componentHash)
+      end
 
-		# insert components into the db
-		list_components_files.each do |component|
-			@component = Xslt_component.new(component)
-			@component.save
-		end
-	    redirect to("/admin/templates")
+      # insert components into the db
+      list_components_files.each do |component|
+          @component = Xslt_component.new(component)
+          @component.save
+      end
+      redirect to("/admin/templates")
 
-        haml :add_template, :encode_html => true
-    end
+      haml :add_template, :encode_html => true
+  end
 end
 
 # Manage Templated Reports

--- a/routes/admin.rb
+++ b/routes/admin.rb
@@ -458,7 +458,7 @@ post '/admin/templates/add' do
       # open up a file handle and write the attachment
       File.open(xslt_file, 'wb') {|f| f.write(xslt) }
       #extract the screenshot names from the file
-      screenshot_names = xslt.scan(/\[!!(.*?)!!]/)
+      screenshot_names = xslt.scan(/\[!!(.*?)!!\]/)
       # delete the file data from the attachment
       datax = Hash.new
       # to prevent traversal we hardcode this

--- a/routes/admin.rb
+++ b/routes/admin.rb
@@ -548,7 +548,7 @@ post '/admin/templates/edit' do
     	# open up a file handle and write the attachment
 	    File.open(xslt_file, 'wb') {|f| f.write(xslt) }
       #extract the screenshot names from the file
-      screenshot_names = xslt.scan(/\[!!(.*?)!!]/)
+      screenshot_names = xslt.scan(/\[!!(.*?)!!\]/)
 	    # delete the file data from the attachment
 	    datax = Hash.new
 	    # to prevent traversal we hardcode this

--- a/server.rb
+++ b/server.rb
@@ -34,7 +34,7 @@ class Server < Sinatra::Application
     #Set Logging
     if(config_options["log_file"] != "")
         log = File.new(config_options["log_file"], "a+")
-        set :logger_out, log  
+        set :logger_out, log
         server_log("Logging set to #{config_options["log_file"]}")
     end
 
@@ -77,7 +77,7 @@ class Server < Sinatra::Application
     set :mod_confidentiality, ["Not Defined","None","Low","High"]
     set :mod_integrity, ["Not Defined","None","Low","High"]
     set :mod_availability, ["Not Defined","None","Low","High"]
-    
+
     #Risk Matrix
     set :severity, ["Low","Medium","High"]
     set :likelihood, ["Low","Medium","High"]
@@ -240,9 +240,9 @@ def image_insert(docx, rand_file, image, end_xml)
     p_id = "d#{rand(36**7).to_s(36)}"
     name = image.description
 
-    image_file = File.open(image.filename_location,'rb') 
-    img_data = image_file.read()              
-    
+    image_file = File.open(image.filename_location,'rb')
+    img_data = image_file.read()
+
     #resize picture to fit into word if it's too big
     if jpeg?(img_data)
       jpeg_dimension = JPEG.new(image.filename_location)
@@ -256,7 +256,7 @@ def image_insert(docx, rand_file, image, end_xml)
       width = 400
       height = 200
     end
-    while width > 720 do #fits nicely into word
+    while width > 710 or height > 790 do #fits nicely into word
         width = width - (width/20)
         height = height - (height/20)
     end
@@ -304,7 +304,7 @@ end
 
 def get_plugin_list
     menu = []
-    
+
     Dir[File.join(File.dirname(__FILE__), "plugins/**/", "*.json")].each { |lib|
         pl = JSON.parse(File.open(lib).read)
         a = {}

--- a/views/list_attachments.haml
+++ b/views/list_attachments.haml
@@ -9,10 +9,8 @@
           %tbody
             - @attachments.each do |attachment|
               %tr
-                %td{:style => 'width: 30%'}
+                %td{:style => 'width: 70%'}
                   #{attachment.description}
-                %td{:style => 'width: 40%' }
-                  #{attachment.caption}
                 %td{:style => 'width: 30%'}
                   %a{ :class => "btn btn-info", :href => "/report/#{attachment.report_id}/attachments/#{attachment.id}"}
                     %i{:class => 'icon-play-circle icon-white', :title => 'Preview'}
@@ -21,6 +19,36 @@
 
   - else
     No Attachments Available.
+  %br
+  - if not @screenshot_names.to_s.empty?
+    %h3 The following screenshot variables were found in your report template:
+    %br
+    .table.table-striped
+      %table
+        %tbody
+          %col{:align => "left"}
+          %col{:align => "center"}
+          %tr
+            %td
+              %strong
+                Screenshot Name
+            %td
+              %strong
+                Uploaded?
+          - @screenshot_names.split(",").each do |ss|
+            %tr
+              %td
+                #{ss}
+              %td{:style => "text-align: center"}
+                - found = false
+                - @attachments.each do |att|
+                  - if att.description == ss
+                    - found = true
+                    %i.fa.fa-check{:style => "color:green"}
+                - if found == false
+                  %i.fa.fa-times{:style => "color:red"}
+
+
 
 :javascript
   function confirmDelete(evt) {


### PR DESCRIPTION
This PR adds the ツ metacharacter, which acts this way :

If in the template, there's an attachment name between ツ, it will be replaced by the corresponding screenshot during the report generation.

For exemple :

- An admin upload the following template

![image](https://user-images.githubusercontent.com/3451172/30477267-d9705f9e-9a0c-11e7-8a07-b0fe52bfdc6b.png)

- An user upload the aforementioned attachment 

![image](https://user-images.githubusercontent.com/3451172/30477335-0b84338e-9a0d-11e7-9891-e4a27417fb5a.png)

- The uploaded screenshot is inserted, while the line refering to the screenshot that wasn't uploaded is deleted

![image](https://user-images.githubusercontent.com/3451172/30477373-300d4d94-9a0d-11e7-8cbb-9f2da4c7fb14.png)

Credit where credit is due : @4B3l0 did most of the work here :-)




