### PR TITLE
Fixed the 'Sinatra::Base#options is deprecated' warning.

### DIFF
--- a/views/create_finding.haml
+++ b/views/create_finding.haml
@@ -16,13 +16,13 @@
         %label{ :class => "control-label", :for => "assessment_type" } Assessment Type
         .controls
           %select{ :name => "assessment_type" }
-            - options.assessment_types.each do |type|
+            - settings.assessment_types.each do |type|
               %option #{type}
     .control-group
       %label{ :class => "control-label", :for => "type" } Finding Type
       .controls
         %select{ :name => "type" }
-          - options.finding_types.each do |type|
+          - settings.finding_types.each do |type|
             %option #{type}
     - if @nessusmap
       .control-group
@@ -91,220 +91,220 @@
                 // AV
                 if(part.includes("AV:")){
                 if(part.includes(":L")){
-                document.getElementById('av').selectedIndex=0;        
+                document.getElementById('av').selectedIndex=0;
                 }
                 if(part.includes(":A")){
-                document.getElementById('av').selectedIndex=1;        
+                document.getElementById('av').selectedIndex=1;
                 }
                 if(part.includes(":N")){
-                document.getElementById('av').selectedIndex=2;        
+                document.getElementById('av').selectedIndex=2;
                 }
-                }        
+                }
 
                 // AC
                 if(part.includes("AC:")){
                 if(part.includes(":H")){
-                document.getElementById('ac').selectedIndex=0;        
+                document.getElementById('ac').selectedIndex=0;
                 }
                 if(part.includes(":M")){
-                document.getElementById('ac').selectedIndex=1;        
+                document.getElementById('ac').selectedIndex=1;
                 }
                 if(part.includes(":L")){
-                document.getElementById('ac').selectedIndex=2;        
+                document.getElementById('ac').selectedIndex=2;
                 }
-                }        
+                }
 
                 // AU
                 if(part.includes("AU:")){
                 if(part.includes(":M")){
-                document.getElementById('au').selectedIndex=0;        
+                document.getElementById('au').selectedIndex=0;
                 }
                 if(part.includes(":S")){
-                document.getElementById('au').selectedIndex=1;        
+                document.getElementById('au').selectedIndex=1;
                 }
                 if(part.includes(":N")){
-                document.getElementById('au').selectedIndex=2;        
+                document.getElementById('au').selectedIndex=2;
                 }
-                }        
+                }
 
                 // C
                 if(part.includes("C:") && !part.includes("AC:")){
                 if(part.includes(":N")){
-                document.getElementById('c').selectedIndex=0;        
+                document.getElementById('c').selectedIndex=0;
                 }
                 if(part.includes(":P")){
-                document.getElementById('c').selectedIndex=1;        
+                document.getElementById('c').selectedIndex=1;
                 }
                 if(part.includes(":C")){
-                document.getElementById('c').selectedIndex=2;        
+                document.getElementById('c').selectedIndex=2;
                 }
-                }        
+                }
 
                 // I
                 if(part.includes("I:")){
                 if(part.includes(":N")){
-                document.getElementById('i').selectedIndex=0;        
+                document.getElementById('i').selectedIndex=0;
                 }
                 if(part.includes(":P")){
-                document.getElementById('i').selectedIndex=1;        
+                document.getElementById('i').selectedIndex=1;
                 }
                 if(part.includes(":C")){
-                document.getElementById('i').selectedIndex=2;        
+                document.getElementById('i').selectedIndex=2;
                 }
-                }        
+                }
 
                 // A
                 if(part.includes("A:")){
                 if(part.includes(":N")){
-                document.getElementById('a').selectedIndex=0;        
+                document.getElementById('a').selectedIndex=0;
                 }
                 if(part.includes(":P")){
-                document.getElementById('a').selectedIndex=1;        
+                document.getElementById('a').selectedIndex=1;
                 }
                 if(part.includes(":C")){
-                document.getElementById('a').selectedIndex=2;        
+                document.getElementById('a').selectedIndex=2;
                 }
-                }        
+                }
 
                 // E
                 if(part.includes("E:")){
                 if(part.includes(":ND")){
-                document.getElementById('e').selectedIndex=0;        
+                document.getElementById('e').selectedIndex=0;
                 }
                 if(part.includes(":U")){
-                document.getElementById('e').selectedIndex=1;        
+                document.getElementById('e').selectedIndex=1;
                 }
                 if(part.includes(":POC")){
-                document.getElementById('e').selectedIndex=2;        
+                document.getElementById('e').selectedIndex=2;
                 }
                 if(part.includes(":F")){
-                document.getElementById('e').selectedIndex=3;        
+                document.getElementById('e').selectedIndex=3;
                 }
                 if(part.includes(":H")){
-                document.getElementById('e').selectedIndex=4;        
+                document.getElementById('e').selectedIndex=4;
                 }
-                }        
+                }
 
                 // RL
                 if(part.includes("RL:")){
                 if(part.includes(":ND")){
-                document.getElementById('rl').selectedIndex=0;        
+                document.getElementById('rl').selectedIndex=0;
                 }
                 if(part.includes(":OF")){
-                document.getElementById('rl').selectedIndex=1;        
+                document.getElementById('rl').selectedIndex=1;
                 }
                 if(part.includes(":TF")){
-                document.getElementById('rl').selectedIndex=2;        
+                document.getElementById('rl').selectedIndex=2;
                 }
                 if(part.includes(":W")){
-                document.getElementById('rl').selectedIndex=3;        
+                document.getElementById('rl').selectedIndex=3;
                 }
                 if(part.includes(":U")){
-                document.getElementById('rl').selectedIndex=4;        
+                document.getElementById('rl').selectedIndex=4;
                 }
-                }        
+                }
 
                 // RC
                 if(part.includes("RC:")){
                 if(part.includes(":ND")){
-                document.getElementById('rc').selectedIndex=0;        
+                document.getElementById('rc').selectedIndex=0;
                 }
                 if(part.includes(":UC")){
-                document.getElementById('rc').selectedIndex=1;        
+                document.getElementById('rc').selectedIndex=1;
                 }
                 if(part.includes(":UR")){
-                document.getElementById('rc').selectedIndex=2;        
+                document.getElementById('rc').selectedIndex=2;
                 }
                 if(part.includes(":C")){
-                document.getElementById('rc').selectedIndex=3;        
+                document.getElementById('rc').selectedIndex=3;
                 }
-                }        
+                }
 
                 // CDP
                 if(part.includes("CDP:")){
                 if(part.includes(":ND")){
-                document.getElementById('cdp').selectedIndex=0;        
+                document.getElementById('cdp').selectedIndex=0;
                 }
                 if(part.includes(":N")){
-                document.getElementById('cdp').selectedIndex=1;        
+                document.getElementById('cdp').selectedIndex=1;
                 }
                 if(part.includes(":LM")){
-                document.getElementById('cdp').selectedIndex=2;        
+                document.getElementById('cdp').selectedIndex=2;
                 }
                 if(part.includes(":MH")){
-                document.getElementById('cdp').selectedIndex=3;        
+                document.getElementById('cdp').selectedIndex=3;
                 }
                 if(part.includes(":H")){
-                document.getElementById('cdp').selectedIndex=4;        
+                document.getElementById('cdp').selectedIndex=4;
                 }
-                }        
+                }
 
                 // TD
                 if(part.includes("TD:")){
                 if(part.includes(":ND")){
-                document.getElementById('td').selectedIndex=0;        
+                document.getElementById('td').selectedIndex=0;
                 }
                 if(part.includes(":N")){
-                document.getElementById('td').selectedIndex=1;        
+                document.getElementById('td').selectedIndex=1;
                 }
                 if(part.includes(":L")){
-                document.getElementById('td').selectedIndex=2;        
+                document.getElementById('td').selectedIndex=2;
                 }
                 if(part.includes(":M")){
-                document.getElementById('td').selectedIndex=3;        
+                document.getElementById('td').selectedIndex=3;
                 }
                 if(part.includes(":H")){
-                document.getElementById('td').selectedIndex=4;        
+                document.getElementById('td').selectedIndex=4;
                 }
-                }        
+                }
 
                 // CD
                 if(part.includes("CR:")){
                 if(part.includes(":ND")){
-                document.getElementById('cd').selectedIndex=0;        
+                document.getElementById('cd').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('cd').selectedIndex=1;        
+                document.getElementById('cd').selectedIndex=1;
                 }
                 if(part.includes(":M")){
-                document.getElementById('cd').selectedIndex=2;        
+                document.getElementById('cd').selectedIndex=2;
                 }
                 if(part.includes(":H")){
-                document.getElementById('cd').selectedIndex=3;        
+                document.getElementById('cd').selectedIndex=3;
                 }
-                }        
+                }
 
                 // IR
                 if(part.includes("IR:")){
                 if(part.includes(":ND")){
-                document.getElementById('ir').selectedIndex=0;        
+                document.getElementById('ir').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('ir').selectedIndex=1;        
+                document.getElementById('ir').selectedIndex=1;
                 }
                 if(part.includes(":M")){
-                document.getElementById('ir').selectedIndex=2;        
+                document.getElementById('ir').selectedIndex=2;
                 }
                 if(part.includes(":H")){
-                document.getElementById('ir').selectedIndex=3;        
+                document.getElementById('ir').selectedIndex=3;
                 }
-                }        
+                }
 
                 // AR
                 if(part.includes("AR:")){
                 if(part.includes(":ND")){
-                document.getElementById('ar').selectedIndex=0;        
+                document.getElementById('ar').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('ar').selectedIndex=1;        
+                document.getElementById('ar').selectedIndex=1;
                 }
                 if(part.includes(":M")){
-                document.getElementById('ar').selectedIndex=2;        
+                document.getElementById('ar').selectedIndex=2;
                 }
                 if(part.includes(":H")){
-                document.getElementById('ar').selectedIndex=3;        
+                document.getElementById('ar').selectedIndex=3;
                 }
-                }        
+                }
                 }}
                 var c = new CVSS("cvssboard", {
                 onchange: function() {
@@ -314,11 +314,11 @@
                 }
                 });
 
-                $("#vs").on('change keydown paste input', function(){               
-                updateDropdown(this.value);                
+                $("#vs").on('change keydown paste input', function(){
+                updateDropdown(this.value);
                 });
         .controls
-          %input{:type => "text", :class=>"form-control", :placeholder=>"CVSS Vector String", :id=>"vs", :style=>"width:35em"}  
+          %input{:type => "text", :class=>"form-control", :placeholder=>"CVSS Vector String", :id=>"vs", :style=>"width:35em"}
       .control-group
         %label{ :class => "control-label", :for => "av" } Access Vector
         .controls
@@ -441,220 +441,220 @@
         // AV
         if(part.includes("AV:")){
         if(part.includes(":L")){
-        document.getElementById('av').selectedIndex=0;        
+        document.getElementById('av').selectedIndex=0;
         }
         if(part.includes(":A")){
-        document.getElementById('av').selectedIndex=1;        
+        document.getElementById('av').selectedIndex=1;
         }
         if(part.includes(":N")){
-        document.getElementById('av').selectedIndex=2;        
+        document.getElementById('av').selectedIndex=2;
         }
-        }        
+        }
 
         // AC
         if(part.includes("AC:")){
         if(part.includes(":H")){
-        document.getElementById('ac').selectedIndex=0;        
+        document.getElementById('ac').selectedIndex=0;
         }
         if(part.includes(":M")){
-        document.getElementById('ac').selectedIndex=1;        
+        document.getElementById('ac').selectedIndex=1;
         }
         if(part.includes(":L")){
-        document.getElementById('ac').selectedIndex=2;        
+        document.getElementById('ac').selectedIndex=2;
         }
-        }        
+        }
 
         // AU
         if(part.includes("AU:")){
         if(part.includes(":M")){
-        document.getElementById('au').selectedIndex=0;        
+        document.getElementById('au').selectedIndex=0;
         }
         if(part.includes(":S")){
-        document.getElementById('au').selectedIndex=1;        
+        document.getElementById('au').selectedIndex=1;
         }
         if(part.includes(":N")){
-        document.getElementById('au').selectedIndex=2;        
+        document.getElementById('au').selectedIndex=2;
         }
-        }        
+        }
 
         // C
         if(part.includes("C:")){
         if(part.includes(":N")){
-        document.getElementById('c').selectedIndex=0;        
+        document.getElementById('c').selectedIndex=0;
         }
         if(part.includes(":P")){
-        document.getElementById('c').selectedIndex=1;        
+        document.getElementById('c').selectedIndex=1;
         }
         if(part.includes(":C")){
-        document.getElementById('c').selectedIndex=2;        
+        document.getElementById('c').selectedIndex=2;
         }
-        }        
+        }
 
         // I
         if(part.includes("I:")){
         if(part.includes(":N")){
-        document.getElementById('i').selectedIndex=0;        
+        document.getElementById('i').selectedIndex=0;
         }
         if(part.includes(":P")){
-        document.getElementById('i').selectedIndex=1;        
+        document.getElementById('i').selectedIndex=1;
         }
         if(part.includes(":C")){
-        document.getElementById('i').selectedIndex=2;        
+        document.getElementById('i').selectedIndex=2;
         }
-        }        
+        }
 
         // A
         if(part.includes("A:")){
         if(part.includes(":N")){
-        document.getElementById('a').selectedIndex=0;        
+        document.getElementById('a').selectedIndex=0;
         }
         if(part.includes(":P")){
-        document.getElementById('a').selectedIndex=1;        
+        document.getElementById('a').selectedIndex=1;
         }
         if(part.includes(":C")){
-        document.getElementById('a').selectedIndex=2;        
+        document.getElementById('a').selectedIndex=2;
         }
-        }        
+        }
 
         // E
         if(part.includes("E:")){
         if(part.includes(":ND")){
-        document.getElementById('e').selectedIndex=0;        
+        document.getElementById('e').selectedIndex=0;
         }
         if(part.includes(":U")){
-        document.getElementById('e').selectedIndex=1;        
+        document.getElementById('e').selectedIndex=1;
         }
         if(part.includes(":POC")){
-        document.getElementById('e').selectedIndex=2;        
+        document.getElementById('e').selectedIndex=2;
         }
         if(part.includes(":F")){
-        document.getElementById('e').selectedIndex=3;        
+        document.getElementById('e').selectedIndex=3;
         }
         if(part.includes(":H")){
-        document.getElementById('e').selectedIndex=4;        
+        document.getElementById('e').selectedIndex=4;
         }
-        }        
+        }
 
         // RL
         if(part.includes("RL:")){
         if(part.includes(":ND")){
-        document.getElementById('rl').selectedIndex=0;        
+        document.getElementById('rl').selectedIndex=0;
         }
         if(part.includes(":OF")){
-        document.getElementById('rl').selectedIndex=1;        
+        document.getElementById('rl').selectedIndex=1;
         }
         if(part.includes(":TF")){
-        document.getElementById('rl').selectedIndex=2;        
+        document.getElementById('rl').selectedIndex=2;
         }
         if(part.includes(":W")){
-        document.getElementById('rl').selectedIndex=3;        
+        document.getElementById('rl').selectedIndex=3;
         }
         if(part.includes(":U")){
-        document.getElementById('rl').selectedIndex=4;        
+        document.getElementById('rl').selectedIndex=4;
         }
-        }        
+        }
 
         // RC
         if(part.includes("RC:")){
         if(part.includes(":ND")){
-        document.getElementById('rc').selectedIndex=0;        
+        document.getElementById('rc').selectedIndex=0;
         }
         if(part.includes(":UC")){
-        document.getElementById('rc').selectedIndex=1;        
+        document.getElementById('rc').selectedIndex=1;
         }
         if(part.includes(":UR")){
-        document.getElementById('rc').selectedIndex=2;        
+        document.getElementById('rc').selectedIndex=2;
         }
         if(part.includes(":C")){
-        document.getElementById('rc').selectedIndex=3;        
+        document.getElementById('rc').selectedIndex=3;
         }
-        }        
+        }
 
         // CDP
         if(part.includes("CDP:")){
         if(part.includes(":ND")){
-        document.getElementById('cdp').selectedIndex=0;        
+        document.getElementById('cdp').selectedIndex=0;
         }
         if(part.includes(":N")){
-        document.getElementById('cdp').selectedIndex=1;        
+        document.getElementById('cdp').selectedIndex=1;
         }
         if(part.includes(":LM")){
-        document.getElementById('cdp').selectedIndex=2;        
+        document.getElementById('cdp').selectedIndex=2;
         }
         if(part.includes(":MH")){
-        document.getElementById('cdp').selectedIndex=3;        
+        document.getElementById('cdp').selectedIndex=3;
         }
         if(part.includes(":H")){
-        document.getElementById('cdp').selectedIndex=4;        
+        document.getElementById('cdp').selectedIndex=4;
         }
-        }        
+        }
 
         // TD
         if(part.includes("TD:")){
         if(part.includes(":ND")){
-        document.getElementById('td').selectedIndex=0;        
+        document.getElementById('td').selectedIndex=0;
         }
         if(part.includes(":N")){
-        document.getElementById('td').selectedIndex=1;        
+        document.getElementById('td').selectedIndex=1;
         }
         if(part.includes(":L")){
-        document.getElementById('td').selectedIndex=2;        
+        document.getElementById('td').selectedIndex=2;
         }
         if(part.includes(":M")){
-        document.getElementById('td').selectedIndex=3;        
+        document.getElementById('td').selectedIndex=3;
         }
         if(part.includes(":H")){
-        document.getElementById('td').selectedIndex=4;        
+        document.getElementById('td').selectedIndex=4;
         }
-        }        
+        }
 
         // CD
         if(part.includes("CR:")){
         if(part.includes(":ND")){
-        document.getElementById('cd').selectedIndex=0;        
+        document.getElementById('cd').selectedIndex=0;
         }
         if(part.includes(":L")){
-        document.getElementById('cd').selectedIndex=1;        
+        document.getElementById('cd').selectedIndex=1;
         }
         if(part.includes(":M")){
-        document.getElementById('cd').selectedIndex=2;        
+        document.getElementById('cd').selectedIndex=2;
         }
         if(part.includes(":H")){
-        document.getElementById('cd').selectedIndex=3;        
+        document.getElementById('cd').selectedIndex=3;
         }
-        }        
+        }
 
         // IR
         if(part.includes("IR:")){
         if(part.includes(":ND")){
-        document.getElementById('ir').selectedIndex=0;        
+        document.getElementById('ir').selectedIndex=0;
         }
         if(part.includes(":L")){
-        document.getElementById('ir').selectedIndex=1;        
+        document.getElementById('ir').selectedIndex=1;
         }
         if(part.includes(":M")){
-        document.getElementById('ir').selectedIndex=2;        
+        document.getElementById('ir').selectedIndex=2;
         }
         if(part.includes(":H")){
-        document.getElementById('ir').selectedIndex=3;        
+        document.getElementById('ir').selectedIndex=3;
         }
-        }        
+        }
 
         // AR
         if(part.includes("AR:")){
         if(part.includes(":ND")){
-        document.getElementById('ar').selectedIndex=0;        
+        document.getElementById('ar').selectedIndex=0;
         }
         if(part.includes(":L")){
-        document.getElementById('ar').selectedIndex=1;        
+        document.getElementById('ar').selectedIndex=1;
         }
         if(part.includes(":M")){
-        document.getElementById('ar').selectedIndex=2;        
+        document.getElementById('ar').selectedIndex=2;
         }
         if(part.includes(":H")){
-        document.getElementById('ar').selectedIndex=3;        
+        document.getElementById('ar').selectedIndex=3;
         }
-        }        
+        }
 
         }
         });
@@ -665,13 +665,13 @@
             %option QUICK
             %option PLANNED
             %option INVOLVED
-    - elsif @cvssv3      
+    - elsif @cvssv3
       .control-group
         %label{ :class => "control-label", :for => "attack_vector" }
           %a{:href=> '#mymodal', "data-toggle"=>'modal', :class=>'btn btn-info'}
             CVSS Vector String
         .controls
-          %input{:type => "text", :class=>"form-control", :placeholder=>"CVSS Vector String", :id=>"vs", :style=>"width:35em"}  
+          %input{:type => "text", :class=>"form-control", :placeholder=>"CVSS Vector String", :id=>"vs", :style=>"width:35em"}
         .modal{:id=>'mymodal', :class=>'modal hide fade', :tabindex=>'-1', :role=>'dialog', "aria-labelledby"=>'modal-label', "aria-hidden"=>'true'}
           .modal-header
             %button{:type=>'button', :class=>'close', "data-dismiss"=>"modal", "aria-hidden"=>"true"}
@@ -684,7 +684,7 @@
             %div{ :id=>"cvssboard"}
               %script
                 function updateDropdown(score){
-                
+
                 var vector = score.trim().split("/");
                 for(var i in vector){
                 var part = vector[i];
@@ -698,326 +698,326 @@
                 // LANP
                 if(part.includes("AV:") && !part.includes("MAV:")){
                 if(part.includes(":L")){
-                document.getElementById('attack_vector').selectedIndex=0;        
+                document.getElementById('attack_vector').selectedIndex=0;
                 }
                 if(part.includes(":A")){
-                document.getElementById('attack_vector').selectedIndex=1;        
+                document.getElementById('attack_vector').selectedIndex=1;
                 }
                 if(part.includes(":N")){
-                document.getElementById('attack_vector').selectedIndex=2;        
+                document.getElementById('attack_vector').selectedIndex=2;
                 }
                 if(part.includes(":P")){
-                document.getElementById('attack_vector').selectedIndex=3;        
+                document.getElementById('attack_vector').selectedIndex=3;
                 }
-                }        
+                }
 
                 // AC
                 if(part.includes("AC:")  && !part.includes("MAC:")){
                 if(part.includes(":L")){
-                document.getElementById('attack_complexity').selectedIndex=0;        
+                document.getElementById('attack_complexity').selectedIndex=0;
                 }
                 if(part.includes(":H")){
-                document.getElementById('attack_complexity').selectedIndex=1;        
+                document.getElementById('attack_complexity').selectedIndex=1;
                 }
-                }        
+                }
 
                 // PR NLH
                 if(part.includes("PR:")  && !part.includes("MPR:")){
                 if(part.includes(":N")){
-                document.getElementById('privileges_required').selectedIndex=0;        
+                document.getElementById('privileges_required').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('privileges_required').selectedIndex=1;        
+                document.getElementById('privileges_required').selectedIndex=1;
                 }
                 if(part.includes(":H")){
-                document.getElementById('privileges_required').selectedIndex=2;        
+                document.getElementById('privileges_required').selectedIndex=2;
                 }
-                }        
+                }
 
                 // UI
                 if(part.includes("UI:")){
                 if(part.includes(":N")){
-                document.getElementById('user_interaction').selectedIndex=0;        
+                document.getElementById('user_interaction').selectedIndex=0;
                 }
                 if(part.includes(":R")){
-                document.getElementById('user_interaction').selectedIndex=1;        
+                document.getElementById('user_interaction').selectedIndex=1;
                 }
-                }        
+                }
 
                 // S
                 if(part.includes("S:")  && !part.includes("MS:")){
                 if(part.includes(":U")){
-                document.getElementById('scope').selectedIndex=0;        
+                document.getElementById('scope').selectedIndex=0;
                 }
                 if(part.includes(":C")){
-                document.getElementById('scope').selectedIndex=1;        
+                document.getElementById('scope').selectedIndex=1;
                 }
-                }        
+                }
 
                 // I
                 if(part.includes("I:")  && !part.includes("MI:")){
                 if(part.includes(":N")){
-                document.getElementById('integrity').selectedIndex=0;        
+                document.getElementById('integrity').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('integrity').selectedIndex=1;        
+                document.getElementById('integrity').selectedIndex=1;
                 }
                 if(part.includes(":H")){
-                document.getElementById('integrity').selectedIndex=2;        
+                document.getElementById('integrity').selectedIndex=2;
                 }
-                }        
+                }
 
                 // C
                 if(part.includes("C:") && !part.includes("MC:") && !part.includes("MAC:")){
                 if(part.includes(":N")){
-                document.getElementById('confidentiality-impact').selectedIndex=0;        
+                document.getElementById('confidentiality-impact').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('confidentiality-impact').selectedIndex=1;        
+                document.getElementById('confidentiality-impact').selectedIndex=1;
                 }
                 if(part.includes(":H")){
-                document.getElementById('confidentiality-impact').selectedIndex=2;        
+                document.getElementById('confidentiality-impact').selectedIndex=2;
                 }
-                }        
+                }
 
                 // A
                 if(part.includes("A:")  && !part.includes("MA:")){
                 if(part.includes(":N")){
-                document.getElementById('availability').selectedIndex=0;        
+                document.getElementById('availability').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('availability').selectedIndex=1;        
+                document.getElementById('availability').selectedIndex=1;
                 }
                 if(part.includes(":H")){
-                document.getElementById('availability').selectedIndex=2;        
+                document.getElementById('availability').selectedIndex=2;
                 }
-                }        
+                }
 
                 // Exploit Code Maturity
                 if(part.includes("E:")){
                 if(part.includes(":X")){
-                document.getElementById('exploit_maturity').selectedIndex=0;        
+                document.getElementById('exploit_maturity').selectedIndex=0;
                 }
                 if(part.includes(":U")){
-                document.getElementById('exploit_maturity').selectedIndex=1;        
+                document.getElementById('exploit_maturity').selectedIndex=1;
                 }
                 if(part.includes(":P")){
-                document.getElementById('exploit_maturity').selectedIndex=2;        
+                document.getElementById('exploit_maturity').selectedIndex=2;
                 }
                 if(part.includes(":F")){
-                document.getElementById('exploit_maturity').selectedIndex=3;        
+                document.getElementById('exploit_maturity').selectedIndex=3;
                 }
-                }        
+                }
 
 
                 // Remediation Level
                 if(part.includes("RL:")){
                 if(part.includes(":X")){
-                document.getElementById('remeditation_level').selectedIndex=0;        
+                document.getElementById('remeditation_level').selectedIndex=0;
                 }
                 if(part.includes(":O")){
-                document.getElementById('remeditation_level').selectedIndex=1;        
+                document.getElementById('remeditation_level').selectedIndex=1;
                 }
                 if(part.includes(":T")){
-                document.getElementById('remeditation_level').selectedIndex=2;        
+                document.getElementById('remeditation_level').selectedIndex=2;
                 }
                 if(part.includes(":W")){
-                document.getElementById('remeditation_level').selectedIndex=3;        
+                document.getElementById('remeditation_level').selectedIndex=3;
                 }
                 if(part.includes(":U")){
-                document.getElementById('remeditation_level').selectedIndex=4;        
+                document.getElementById('remeditation_level').selectedIndex=4;
                 }
-                }        
+                }
 
 
                 // report confidence
                 if(part.includes("RC:")){
                 if(part.includes(":X")){
-                document.getElementById('report_confidence').selectedIndex=0;        
+                document.getElementById('report_confidence').selectedIndex=0;
                 }
                 if(part.includes(":U")){
-                document.getElementById('report_confidence').selectedIndex=1;        
+                document.getElementById('report_confidence').selectedIndex=1;
                 }
                 if(part.includes(":R")){
-                document.getElementById('report_confidence').selectedIndex=2;        
+                document.getElementById('report_confidence').selectedIndex=2;
                 }
                 if(part.includes(":C")){
-                document.getElementById('report_confidence').selectedIndex=3;        
+                document.getElementById('report_confidence').selectedIndex=3;
                 }
-                }        
+                }
 
                 // confidentiality-requirement
                 if(part.includes("CR:")){
                 if(part.includes(":X")){
-                document.getElementById('confidentiality_requirement').selectedIndex=0;        
+                document.getElementById('confidentiality_requirement').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('confidentiality_requirement').selectedIndex=1;        
+                document.getElementById('confidentiality_requirement').selectedIndex=1;
                 }
                 if(part.includes(":M")){
-                document.getElementById('confidentiality_requirement').selectedIndex=2;        
+                document.getElementById('confidentiality_requirement').selectedIndex=2;
                 }
                 if(part.includes(":H")){
-                document.getElementById('confidentiality_requirement').selectedIndex=3;        
+                document.getElementById('confidentiality_requirement').selectedIndex=3;
                 }
-                }        
+                }
 
                 // integrity-requirement
                 if(part.includes("IR:")){
                 if(part.includes(":X")){
-                document.getElementById('integrity_requirement').selectedIndex=0;        
+                document.getElementById('integrity_requirement').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('integrity_requirement').selectedIndex=1;        
+                document.getElementById('integrity_requirement').selectedIndex=1;
                 }
                 if(part.includes(":M")){
-                document.getElementById('integrity_requirement').selectedIndex=2;        
+                document.getElementById('integrity_requirement').selectedIndex=2;
                 }
                 if(part.includes(":H")){
-                document.getElementById('integrity_requirement').selectedIndex=3;        
+                document.getElementById('integrity_requirement').selectedIndex=3;
                 }
-                }        
+                }
 
 
                 // integrity-requirement
                 if(part.includes("AR:")){
                 if(part.includes(":X")){
-                document.getElementById('availability_requirement').selectedIndex=0;        
+                document.getElementById('availability_requirement').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('availability_requirement').selectedIndex=1;        
+                document.getElementById('availability_requirement').selectedIndex=1;
                 }
                 if(part.includes(":M")){
-                document.getElementById('availability_requirement').selectedIndex=2;        
+                document.getElementById('availability_requirement').selectedIndex=2;
                 }
                 if(part.includes(":H")){
-                document.getElementById('availability_requirement').selectedIndex=3;        
+                document.getElementById('availability_requirement').selectedIndex=3;
                 }
-                }        
+                }
 
                 // modified-attack-vector
                 if(part.includes("MAV:")){
                 if(part.includes(":X")){
-                document.getElementById('mod_attack_vector').selectedIndex=0;        
+                document.getElementById('mod_attack_vector').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('mod_attack_vector').selectedIndex=1;        
+                document.getElementById('mod_attack_vector').selectedIndex=1;
                 }
                 if(part.includes(":A")){
-                document.getElementById('mod_attack_vector').selectedIndex=2;        
+                document.getElementById('mod_attack_vector').selectedIndex=2;
                 }
                 if(part.includes(":N")){
-                document.getElementById('mod_attack_vector').selectedIndex=3;        
+                document.getElementById('mod_attack_vector').selectedIndex=3;
                 }
                 if(part.includes(":P")){
-                document.getElementById('mod_attack_vector').selectedIndex=4;        
+                document.getElementById('mod_attack_vector').selectedIndex=4;
                 }
-                }        
+                }
 
                 // modified-attack-vector
                 if(part.includes("MAC:")){
                 if(part.includes(":X")){
-                document.getElementById('mod_attack_complexity').selectedIndex=0;        
+                document.getElementById('mod_attack_complexity').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('mod_attack_complexity').selectedIndex=1;        
+                document.getElementById('mod_attack_complexity').selectedIndex=1;
                 }
                 if(part.includes(":H")){
-                document.getElementById('mod_attack_complexity').selectedIndex=2;        
+                document.getElementById('mod_attack_complexity').selectedIndex=2;
                 }
-                }        
+                }
 
                 // modified-privileges-Required
                 if(part.includes("MPR:")){
                 if(part.includes(":X")){
-                document.getElementById('mod_privileges_required').selectedIndex=0;        
+                document.getElementById('mod_privileges_required').selectedIndex=0;
                 }
                 if(part.includes(":N")){
-                document.getElementById('mod_privileges_required').selectedIndex=1;        
+                document.getElementById('mod_privileges_required').selectedIndex=1;
                 }
                 if(part.includes(":L")){
-                document.getElementById('mod_privileges_required').selectedIndex=2;        
+                document.getElementById('mod_privileges_required').selectedIndex=2;
                 }
                 if(part.includes(":H")){
-                document.getElementById('mod_privileges_required').selectedIndex=3;        
+                document.getElementById('mod_privileges_required').selectedIndex=3;
                 }
-                }        
+                }
 
                 // modified-user-interaction
                 if(part.includes("MUI:")){
                 if(part.includes(":X")){
-                document.getElementById('mod_user_interaction').selectedIndex=0;        
+                document.getElementById('mod_user_interaction').selectedIndex=0;
                 }
                 if(part.includes(":N")){
-                document.getElementById('mod_user_interaction').selectedIndex=1;        
+                document.getElementById('mod_user_interaction').selectedIndex=1;
                 }
                 if(part.includes(":R")){
-                document.getElementById('mod_user_interaction').selectedIndex=2;        
+                document.getElementById('mod_user_interaction').selectedIndex=2;
                 }
-                }        
+                }
 
 
                 // modified-scope
                 if(part.includes("MS:")){
                 if(part.includes(":X")){
-                document.getElementById('mod_scope').selectedIndex=0;        
+                document.getElementById('mod_scope').selectedIndex=0;
                 }
                 if(part.includes(":U")){
-                document.getElementById('mod_scope').selectedIndex=1;        
+                document.getElementById('mod_scope').selectedIndex=1;
                 }
                 if(part.includes(":C")){
-                document.getElementById('mod_scope').selectedIndex=2;        
+                document.getElementById('mod_scope').selectedIndex=2;
                 }
-                }        
+                }
 
                 // modified-confidentiality
                 if(part.includes("MC:")){
                 if(part.includes(":X")){
-                document.getElementById('mod_confidentiality').selectedIndex=0;        
+                document.getElementById('mod_confidentiality').selectedIndex=0;
                 }
                 if(part.includes(":N")){
-                document.getElementById('mod_confidentiality').selectedIndex=1;        
+                document.getElementById('mod_confidentiality').selectedIndex=1;
                 }
                 if(part.includes(":L")){
-                document.getElementById('mod_confidentiality').selectedIndex=2;        
+                document.getElementById('mod_confidentiality').selectedIndex=2;
                 }
                 if(part.includes(":H")){
-                document.getElementById('mod_confidentiality').selectedIndex=3;        
+                document.getElementById('mod_confidentiality').selectedIndex=3;
                 }
-                }        
+                }
 
                 // modified-integrity
                 if(part.includes("MI:")){
                 if(part.includes(":X")){
-                document.getElementById('mod_integrity').selectedIndex=0;        
+                document.getElementById('mod_integrity').selectedIndex=0;
                 }
                 if(part.includes(":N")){
-                document.getElementById('mod_integrity').selectedIndex=1;        
+                document.getElementById('mod_integrity').selectedIndex=1;
                 }
                 if(part.includes(":L")){
-                document.getElementById('mod_integrity').selectedIndex=2;        
+                document.getElementById('mod_integrity').selectedIndex=2;
                 }
                 if(part.includes(":H")){
-                document.getElementById('mod_integrity').selectedIndex=3;        
+                document.getElementById('mod_integrity').selectedIndex=3;
                 }
-                }        
+                }
 
 
                 // modified-availability
                 if(part.includes("MA:")){
                 if(part.includes(":X")){
-                document.getElementById('mod_availability').selectedIndex=0;        
+                document.getElementById('mod_availability').selectedIndex=0;
                 }
                 if(part.includes(":N")){
-                document.getElementById('mod_availability').selectedIndex=1;        
+                document.getElementById('mod_availability').selectedIndex=1;
                 }
                 if(part.includes(":L")){
-                document.getElementById('mod_availability').selectedIndex=2;        
+                document.getElementById('mod_availability').selectedIndex=2;
                 }
                 if(part.includes(":H")){
-                document.getElementById('mod_availability').selectedIndex=3;        
+                document.getElementById('mod_availability').selectedIndex=3;
                 }
-                }        
+                }
                 }}
 
                 var c = new CVSS("cvssboard", {
@@ -1027,141 +1027,141 @@
                 }
                 });
 
-                $("#vs").on('change keydown paste input', function(){               
-                updateDropdown(this.value);                
+                $("#vs").on('change keydown paste input', function(){
+                updateDropdown(this.value);
                 });
       %span{:class=>"input-group-btn"}
       .control-group
         %label{ :class => "control-label", :for => "attack_vector" } Attack Vector
         .controls
           %select{ :name => "attack_vector", :id => "attack_vector" }
-            - options.attack_vector.each do |attack_vector|
+            - settings.attack_vector.each do |attack_vector|
               %option #{attack_vector}
       .control-group
         %label{ :class => "control-label", :for => "attack_complexity" } Attack Complexity
         .controls
           %select{ :name => "attack_complexity", :id =>  "attack_complexity"}
-            - options.attack_complexity.each do |attack_complexity|
+            - settings.attack_complexity.each do |attack_complexity|
               %option #{attack_complexity}
       .control-group
         %label{ :class => "control-label", :for => "privileges_required" } Privileges Required
         .controls
           %select{ :name => "privileges_required", :id =>  "privileges_required"}
-            - options.privileges_required.each do |privileges_required|
+            - settings.privileges_required.each do |privileges_required|
               %option #{privileges_required}
       .control-group
         %label{ :class => "control-label", :for => "user_interaction" } User Interaction
         .controls
           %select{ :name => "user_interaction", :id => "user_interaction" }
-            - options.user_interaction.each do |user_interaction|
+            - settings.user_interaction.each do |user_interaction|
               %option #{user_interaction}
       .control-group
         %label{ :class => "control-label", :for => "scope_cvss" } Scope
         .controls
           %select{ :name => "scope_cvss", :id => "scope" }
-            - options.scope_cvss.each do |scope_cvss|
+            - settings.scope_cvss.each do |scope_cvss|
               %option #{scope_cvss}
       .control-group
         %label{ :class => "control-label", :for => "confidentiality" } Confidentiality
         .controls
           %select{ :name => "confidentiality", :id => "confidentiality-impact" }
-            - options.confidentiality.each do |confidentiality|
+            - settings.confidentiality.each do |confidentiality|
               %option #{confidentiality}
       .control-group
         %label{ :class => "control-label", :for => "integrity" } Integrity
         .controls
           %select{ :name => "integrity", :id => "integrity" }
-            - options.integrity.each do |integrity|
+            - settings.integrity.each do |integrity|
               %option #{integrity}
       .control-group
         %label{ :class => "control-label", :for => "availability" } Availability
         .controls
           %select{ :name => "availability", :id => "availability" }
-            - options.availability.each do |availability|
+            - settings.availability.each do |availability|
               %option #{availability}
       .control-group
         %label{ :class => "control-label", :for => "exploit_maturity" } Exploit Code Maturity
         .controls
           %select{ :name => "exploit_maturity", :id => "exploit_maturity" }
-            - options.exploit_maturity.each do |exploit_maturity|
+            - settings.exploit_maturity.each do |exploit_maturity|
               %option #{exploit_maturity}
       .control-group
         %label{ :class => "control-label", :for => "remeditation_level" } Remediation Level
         .controls
           %select{ :name => "remeditation_level", :id => "remeditation_level" }
-            - options.remeditation_level.each do |remeditation_level|
+            - settings.remeditation_level.each do |remeditation_level|
               %option #{remeditation_level}
       .control-group
         %label{ :class => "control-label", :for => "report_confidence" } Report Confidence
         .controls
           %select{ :name => "report_confidence", :id => "report_confidence" }
-            - options.report_confidence.each do |report_confidence|
+            - settings.report_confidence.each do |report_confidence|
               %option #{report_confidence}
       .control-group
         %label{ :class => "control-label", :for => "confidentiality_requirement" } Confidentiality Requirement
         .controls
           %select{ :name => "confidentiality_requirement", :id => "confidentiality_requirement" }
-            - options.confidentiality_requirement.each do |confidentiality_requirement|
+            - settings.confidentiality_requirement.each do |confidentiality_requirement|
               %option #{confidentiality_requirement}
       .control-group
         %label{ :class => "control-label", :for => "integrity_requirement" } Integrity Requirement
         .controls
           %select{ :name => "integrity_requirement", :id => "integrity_requirement" }
-            - options.integrity_requirement.each do |integrity_requirement|
+            - settings.integrity_requirement.each do |integrity_requirement|
               %option #{integrity_requirement}
       .control-group
         %label{ :class => "control-label", :for => "availability_requirement" } Availability Requirement
         .controls
           %select{ :name => "availability_requirement", :id => "availability_requirement" }
-            - options.availability_requirement.each do |availability_requirement|
+            - settings.availability_requirement.each do |availability_requirement|
               %option #{availability_requirement}
       .control-group
         %label{ :class => "control-label", :for => "mod_attack_vector" } Modified Attack Vector
         .controls
           %select{ :name => "mod_attack_vector", :id => "mod_attack_vector" }
-            - options.mod_attack_vector.each do |mod_attack_vector|
+            - settings.mod_attack_vector.each do |mod_attack_vector|
               %option #{mod_attack_vector}
       .control-group
         %label{ :class => "control-label", :for => "mod_attack_complexity" } Modified Attack Complexity
         .controls
           %select{ :name => "mod_attack_complexity", :id => "mod_attack_complexity"  }
-            - options.mod_attack_complexity.each do |mod_attack_complexity|
+            - settings.mod_attack_complexity.each do |mod_attack_complexity|
               %option #{mod_attack_complexity}
       .control-group
         %label{ :class => "control-label", :for => "mod_privileges_required" } Modified Privileges Required
         .controls
           %select{ :name => "mod_privileges_required", :id => "mod_privileges_required" }
-            - options.mod_privileges_required.each do |mod_privileges_required|
+            - settings.mod_privileges_required.each do |mod_privileges_required|
               %option #{mod_privileges_required}
       .control-group
         %label{ :class => "control-label", :for => "mod_user_interaction" } Modified User Interaction
         .controls
           %select{ :name => "mod_user_interaction", :id => "mod_user_interaction" }
-            - options.mod_user_interaction.each do |mod_user_interaction|
+            - settings.mod_user_interaction.each do |mod_user_interaction|
               %option #{mod_user_interaction}
       .control-group
         %label{ :class => "control-label", :for => "mod_scope" } Modified Scope
         .controls
           %select{ :name => "mod_scope", :id => "mod_scope" }
-            - options.mod_scope.each do |mod_scope|
+            - settings.mod_scope.each do |mod_scope|
               %option #{mod_scope}
       .control-group
         %label{ :class => "control-label", :for => "mod_confidentiality" } Modified Confidentiality
         .controls
           %select{ :name => "mod_confidentiality", :id => "mod_confidentiality" }
-            - options.mod_confidentiality.each do |mod_confidentiality|
+            - settings.mod_confidentiality.each do |mod_confidentiality|
               %option #{mod_confidentiality}
       .control-group
         %label{ :class => "control-label", :for => "mod_integrity" } Modified Integrity
         .controls
           %select{ :name => "mod_integrity", :id => "mod_integrity" }
-            - options.mod_integrity.each do |mod_integrity|
+            - settings.mod_integrity.each do |mod_integrity|
               %option #{mod_integrity}
       .control-group
         %label{ :class => "control-label", :for => "mod_availability" } Modified Availability
         .controls
           %select{ :name => "mod_availability", :id => "mod_availability" }
-            - options.mod_availability.each do |mod_availability|
+            - settings.mod_availability.each do |mod_availability|
               %option #{mod_availability}
     - elsif @riskmatrix
       .control-group
@@ -1177,7 +1177,7 @@
         %label{ :class => "control-label", :for => "severity" } Severity
         .controls
           %select{ :name => "severity" }
-            - options.severity.each do |severity|
+            - settings.severity.each do |severity|
               %option #{severity}
       .control-group
         %label{ :class => "control-label", :for => "severity_rationale" } Severity Rationale
@@ -1187,26 +1187,26 @@
         %label{ :class => "control-label", :for => "likelihood" } Likelihood
         .controls
           %select{ :name => "likelihood" }
-            - options.likelihood.each do |likelihood|
+            - settings.likelihood.each do |likelihood|
               %option #{likelihood}
       .control-group
         %label{ :class => "control-label", :for => "likelihood_rationale" } Likelihood Rationale
         .controls
-          %textarea{ :rows => '3', :class => 'input-xxlarge allowMarkupShortcut', :id => 'likelihood_rationale', :name => 'likelihood_rationale'}       
-             
+          %textarea{ :rows => '3', :class => 'input-xxlarge allowMarkupShortcut', :id => 'likelihood_rationale', :name => 'likelihood_rationale'}
+
     - else
       .control-group
         %label{ :class => "control-label", :for => "effort" } Remediation Effort
         .controls
           %select{ :name => "effort" }
             - if @finding
-              - options.effort.each do |effort|
+              - settings.effort.each do |effort|
                 - if effort == @finding.effort
                   %option{ :selected => "selected" } #{effort}
                 - else
                   %option #{effort}
             - else
-              - options.effort.each do |effort|
+              - settings.effort.each do |effort|
                 %option #{effort}
       .control-group
         %label{ :class => "control-label", :for => "risk" } Vulnerability Risk Level
@@ -1346,8 +1346,8 @@
           %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :name => 'presentation_rem_points'}
             - if @finding
               - if @finding.presentation_rem_points
-                #{meta_markup(@finding.presentation_rem_points)}      
-    
+                #{meta_markup(@finding.presentation_rem_points)}
+
     - id_r = @report ? "/report/#{@report.id}/findings" : "/master/findings"
     %input{:type => 'submit', :value => 'Save'}
     %a{ :href => "#{id_r}"}

--- a/views/findings_add.haml
+++ b/views/findings_add.haml
@@ -4,11 +4,11 @@
     - if @findings
       - if @autoadd
         %h3 Auto Add Findings
-        %h4 
+        %h4
           &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The following findings were automatically selected to be added to your report.
       - else
         %h3 Templated Findings
-        %h4 
+        %h4
           &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Add findings from the template database to your report.
       %br
       &nbsp;
@@ -16,7 +16,7 @@
       %style{:id => "search_style" }
       %span{:class=>"input-group-btn"}
       %script{:type=>"text/javascript"}
-        // credit to http://www.redotheweb.com/2013/05/15/client-side-full-text-search-in-css.html for this 
+        // credit to http://www.redotheweb.com/2013/05/15/client-side-full-text-search-in-css.html for this
         var searchStyle = document.getElementById('search_style');
         document.getElementById('search').addEventListener('input', function() {
         if (!this.value) {
@@ -29,7 +29,7 @@
         .table
           %table{:style => 'width: 90%'}
             %tbody
-            - options.finding_types.each do |type|
+            - settings.finding_types.each do |type|
               %tr
                 %td{:colspan => "2"}
                   %b

--- a/views/findings_edit.haml
+++ b/views/findings_edit.haml
@@ -17,7 +17,7 @@
         %label{ :class => "control-label", :for => "assessment_type" } Assessment Type
         .controls
           %select{ :name => "assessment_type" }
-            - options.assessment_types.each do |type|
+            - settings.assessment_types.each do |type|
               - if @finding
                 - if type == @finding.assessment_type
                   %option{ :selected => "selected" } #{type}
@@ -418,7 +418,7 @@
         %label{ :class => "control-label", :for => "av" } Access Vector
         .controls
           %select{ :name => "av", :id => "av" }
-            - options.av.each do |av|
+            - settings.av.each do |av|
               - if av == @finding.av
                 %option{ :selected => "selected" } #{av}
               - else
@@ -427,7 +427,7 @@
         %label{ :class => "control-label", :for => "ac" } Access Complexity
         .controls
           %select{ :name => "ac", :id => "ac" }
-            - options.ac.each do |ac|
+            - settings.ac.each do |ac|
               - if ac == @finding.ac
                 %option{ :selected => "selected" } #{ac}
               - else
@@ -436,7 +436,7 @@
         %label{ :class => "control-label", :for => "au" } Authentication
         .controls
           %select{ :name => "au", :id => "au" }
-            - options.au.each do |au|
+            - settings.au.each do |au|
               - if au == @finding.au
                 %option{ :selected => "selected" } #{au}
               - else
@@ -445,7 +445,7 @@
         %label{ :class => "control-label", :for => "c" } Confidentiality Impact
         .controls
           %select{ :name => "c", :id => "c" }
-            - options.c.each do |c|
+            - settings.c.each do |c|
               - if c == @finding.c
                 %option{ :selected => "selected" } #{c}
               - else
@@ -454,7 +454,7 @@
         %label{ :class => "control-label", :for => "i" } Integrity Impact
         .controls
           %select{ :name => "i", :id => "i" }
-            - options.i.each do |i|
+            - settings.i.each do |i|
               - if i == @finding.i
                 %option{ :selected => "selected" } #{i}
               - else
@@ -463,7 +463,7 @@
         %label{ :class => "control-label", :for => "a" } Availability Impact
         .controls
           %select{ :name => "a", :id => "a" }
-            - options.a.each do |a|
+            - settings.a.each do |a|
               - if a == @finding.a
                 %option{ :selected => "selected" } #{a}
               - else
@@ -472,7 +472,7 @@
         %label{ :class => "control-label", :for => "e" } Exploitability
         .controls
           %select{ :name => "e", :id => "e" }
-            - options.e.each do |e|
+            - settings.e.each do |e|
               - if e == @finding.e
                 %option{ :selected => "selected" } #{e}
               - else
@@ -481,7 +481,7 @@
         %label{ :class => "control-label", :for => "rl" } Remediation Level
         .controls
           %select{ :name => "rl", :id => "rl" }
-            - options.rl.each do |rl|
+            - settings.rl.each do |rl|
               - if rl == @finding.rl
                 %option{ :selected => "selected" } #{rl}
               - else
@@ -490,7 +490,7 @@
         %label{ :class => "control-label", :for => "rc" } Report Confidence
         .controls
           %select{ :name => "rc", :id => "rc" }
-            - options.rc.each do |rc|
+            - settings.rc.each do |rc|
               - if rc == @finding.rc
                 %option{ :selected => "selected" } #{rc}
               - else
@@ -499,7 +499,7 @@
         %label{ :class => "control-label", :for => "cdp" } Collateral Damage Potential
         .controls
           %select{ :name => "cdp", :id => "cdp" }
-            - options.cdp.each do |cdp|
+            - settings.cdp.each do |cdp|
               - if cdp == @finding.cdp
                 %option{ :selected => "selected" } #{cdp}
               - else
@@ -508,7 +508,7 @@
         %label{ :class => "control-label", :for => "td" } Target Distribution
         .controls
           %select{ :name => "td", :id => "td" }
-            - options.td.each do |td|
+            - settings.td.each do |td|
               - if td == @finding.td
                 %option{ :selected => "selected" } #{td}
               - else
@@ -517,7 +517,7 @@
         %label{ :class => "control-label", :for => "cr" } Confidentiality Requirement
         .controls
           %select{ :name => "cr", :id => "cr" }
-            - options.cr.each do |cr|
+            - settings.cr.each do |cr|
               - if cr == @finding.cr
                 %option{ :selected => "selected" } #{cr}
               - else
@@ -526,7 +526,7 @@
         %label{ :class => "control-label", :for => "ir" } Integrity Requirement
         .controls
           %select{ :name => "ir", :id => "ir" }
-            - options.ir.each do |ir|
+            - settings.ir.each do |ir|
               - if ir == @finding.ir
                 %option{ :selected => "selected" } #{ir}
               - else
@@ -535,7 +535,7 @@
         %label{ :class => "control-label", :for => "ar" } Availability Requirement
         .controls
           %select{ :name => "ar", :id => "ar" }
-            - options.ar.each do |ar|
+            - settings.ar.each do |ar|
               - if ar == @finding.ar
                 %option{ :selected => "selected" } #{ar}
               - else
@@ -910,7 +910,7 @@
         %label{ :class => "control-label", :for => "attack_vector" } Attack Vector
         .controls
           %select{ :name => "attack_vector", :id => "attack_vector"  }
-            - options.attack_vector.each do |attack_vector|
+            - settings.attack_vector.each do |attack_vector|
               - if attack_vector == @finding.attack_vector
                 %option{ :selected => "selected" } #{attack_vector}
               - else
@@ -919,7 +919,7 @@
         %label{ :class => "control-label", :for => "attack_complexity" } Attack Complexity
         .controls
           %select{ :name => "attack_complexity", :id =>  "attack_complexity" }
-            - options.attack_complexity.each do |attack_complexity|
+            - settings.attack_complexity.each do |attack_complexity|
               - if attack_complexity == @finding.attack_complexity
                 %option{ :selected => "selected" } #{attack_complexity}
               - else
@@ -928,7 +928,7 @@
         %label{ :class => "control-label", :for => "privileges_required" } Privileges Required
         .controls
           %select{ :name => "privileges_required", :id =>  "privileges_required" }
-            - options.privileges_required.each do |privileges_required|
+            - settings.privileges_required.each do |privileges_required|
               - if privileges_required == @finding.privileges_required
                 %option{ :selected => "selected" } #{privileges_required}
               - else
@@ -937,7 +937,7 @@
         %label{ :class => "control-label", :for => "user_interaction" } User Interaction
         .controls
           %select{ :name => "user_interaction", :id => "user_interaction"  }
-            - options.user_interaction.each do |user_interaction|
+            - settings.user_interaction.each do |user_interaction|
               - if user_interaction == @finding.user_interaction
                 %option{ :selected => "selected" } #{user_interaction}
               - else
@@ -946,7 +946,7 @@
         %label{ :class => "control-label", :for => "scope_cvss" } Scope
         .controls
           %select{ :name => "scope_cvss", :id => "scope"  }
-            - options.scope_cvss.each do |scope_cvss|
+            - settings.scope_cvss.each do |scope_cvss|
               - if scope_cvss == @finding.scope_cvss
                 %option{ :selected => "selected" } #{scope_cvss}
               - else
@@ -955,7 +955,7 @@
         %label{ :class => "control-label", :for => "confidentiality" } Confidentiality
         .controls
           %select{ :name => "confidentiality", :id => "confidentiality-impact" }
-            - options.confidentiality.each do |confidentiality|
+            - settings.confidentiality.each do |confidentiality|
               - if confidentiality == @finding.confidentiality
                 %option{ :selected => "selected" } #{confidentiality}
               - else
@@ -964,7 +964,7 @@
         %label{ :class => "control-label", :for => "integrity" } Integrity
         .controls
           %select{ :name => "integrity", :id => "integrity" }
-            - options.integrity.each do |integrity|
+            - settings.integrity.each do |integrity|
               - if integrity == @finding.integrity
                 %option{ :selected => "selected" } #{integrity}
               - else
@@ -973,7 +973,7 @@
         %label{ :class => "control-label", :for => "availability" } Availability
         .controls
           %select{ :name => "availability", :id => "availability" }
-            - options.availability.each do |availability|
+            - settings.availability.each do |availability|
               - if availability == @finding.availability
                 %option{ :selected => "selected" } #{availability}
               - else
@@ -982,7 +982,7 @@
         %label{ :class => "control-label", :for => "exploit_maturity" } Exploit Code Maturity
         .controls
           %select{ :name => "exploit_maturity", :id => "exploit_maturity"  }
-            - options.exploit_maturity.each do |exploit_maturity|
+            - settings.exploit_maturity.each do |exploit_maturity|
               - if exploit_maturity == @finding.exploit_maturity
                 %option{ :selected => "selected" } #{exploit_maturity}
               - else
@@ -991,7 +991,7 @@
         %label{ :class => "control-label", :for => "remeditation_level" } Remediation Level
         .controls
           %select{ :name => "remeditation_level", :id => "remeditation_level" }
-            - options.remeditation_level.each do |remeditation_level|
+            - settings.remeditation_level.each do |remeditation_level|
               - if remeditation_level == @finding.remeditation_level
                 %option{ :selected => "selected" } #{remeditation_level}
               - else
@@ -1000,7 +1000,7 @@
         %label{ :class => "control-label", :for => "report_confidence" } Report Confidence
         .controls
           %select{ :name => "report_confidence", :id => "report_confidence" }
-            - options.report_confidence.each do |report_confidence|
+            - settings.report_confidence.each do |report_confidence|
               - if report_confidence == @finding.report_confidence
                 %option{ :selected => "selected" } #{report_confidence}
               - else
@@ -1009,7 +1009,7 @@
         %label{ :class => "control-label", :for => "confidentiality_requirement" } Confidentiality Requirement
         .controls
           %select{ :name => "confidentiality_requirement", :id => "confidentiality_requirement"  }
-            - options.confidentiality_requirement.each do |confidentiality_requirement|
+            - settings.confidentiality_requirement.each do |confidentiality_requirement|
               - if confidentiality_requirement == @finding.confidentiality_requirement
                 %option{ :selected => "selected" } #{confidentiality_requirement}
               - else
@@ -1018,7 +1018,7 @@
         %label{ :class => "control-label", :for => "integrity_requirement" } Integrity Requirement
         .controls
           %select{ :name => "integrity_requirement", :id => "integrity_requirement" }
-            - options.integrity_requirement.each do |integrity_requirement|
+            - settings.integrity_requirement.each do |integrity_requirement|
               - if integrity_requirement == @finding.integrity_requirement
                 %option{ :selected => "selected" } #{integrity_requirement}
               - else
@@ -1027,7 +1027,7 @@
         %label{ :class => "control-label", :for => "availability_requirement" } Availability Requirement
         .controls
           %select{ :name => "availability_requirement", :id => "availability_requirement" }
-            - options.availability_requirement.each do |availability_requirement|
+            - settings.availability_requirement.each do |availability_requirement|
               - if availability_requirement == @finding.availability_requirement
                 %option{ :selected => "selected" } #{availability_requirement}
               - else
@@ -1036,7 +1036,7 @@
         %label{ :class => "control-label", :for => "mod_attack_vector" } Modified Attack Vector
         .controls
           %select{ :name => "mod_attack_vector", :id => "mod_attack_vector" }
-            - options.mod_attack_vector.each do |mod_attack_vector|
+            - settings.mod_attack_vector.each do |mod_attack_vector|
               - if mod_attack_vector == @finding.mod_attack_vector
                 %option{ :selected => "selected" } #{mod_attack_vector}
               - else
@@ -1045,7 +1045,7 @@
         %label{ :class => "control-label", :for => "mod_attack_complexity" } Modified Attack Complexity
         .controls
           %select{ :name => "mod_attack_complexity", :id => "mod_attack_complexity" }
-            - options.mod_attack_complexity.each do |mod_attack_complexity|
+            - settings.mod_attack_complexity.each do |mod_attack_complexity|
               - if mod_attack_complexity == @finding.mod_attack_complexity
                 %option{ :selected => "selected" } #{mod_attack_complexity}
               - else
@@ -1054,7 +1054,7 @@
         %label{ :class => "control-label", :for => "mod_privileges_required" } Modified Privileges Required
         .controls
           %select{ :name => "mod_privileges_required", :id => "mod_privileges_required" }
-            - options.mod_privileges_required.each do |mod_privileges_required|
+            - settings.mod_privileges_required.each do |mod_privileges_required|
               - if mod_privileges_required == @finding.mod_privileges_required
                 %option{ :selected => "selected" } #{mod_privileges_required}
               - else
@@ -1063,7 +1063,7 @@
         %label{ :class => "control-label", :for => "mod_user_interaction" } Modified User Interaction
         .controls
           %select{ :name => "mod_user_interaction", :id => "mod_user_interaction" }
-            - options.mod_user_interaction.each do |mod_user_interaction|
+            - settings.mod_user_interaction.each do |mod_user_interaction|
               - if mod_user_interaction == @finding.mod_user_interaction
                 %option{ :selected => "selected" } #{mod_user_interaction}
               - else
@@ -1072,7 +1072,7 @@
         %label{ :class => "control-label", :for => "mod_scope" } Modified Scope
         .controls
           %select{ :name => "mod_scope", :id => "mod_scope" }
-            - options.mod_scope.each do |mod_scope|
+            - settings.mod_scope.each do |mod_scope|
               - if mod_scope == @finding.mod_scope
                 %option{ :selected => "selected" } #{mod_scope}
               - else
@@ -1081,7 +1081,7 @@
         %label{ :class => "control-label", :for => "mod_confidentiality" } Modified Confidentiality
         .controls
           %select{ :name => "mod_confidentiality", :id => "mod_confidentiality" }
-            - options.mod_confidentiality.each do |mod_confidentiality|
+            - settings.mod_confidentiality.each do |mod_confidentiality|
               - if mod_confidentiality == @finding.mod_confidentiality
                 %option{ :selected => "selected" } #{mod_confidentiality}
               - else
@@ -1090,7 +1090,7 @@
         %label{ :class => "control-label", :for => "mod_integrity" } Modified Integrity
         .controls
           %select{ :name => "mod_integrity", :id => "mod_integrity" }
-            - options.mod_integrity.each do |mod_integrity|
+            - settings.mod_integrity.each do |mod_integrity|
               - if mod_integrity == @finding.mod_integrity
                 %option{ :selected => "selected" } #{mod_integrity}
               - else
@@ -1099,7 +1099,7 @@
         %label{ :class => "control-label", :for => "mod_availability" } Modified Availability
         .controls
           %select{ :name => "mod_availability", :id => "mod_availability" }
-            - options.mod_availability.each do |mod_availability|
+            - settings.mod_availability.each do |mod_availability|
               - if mod_availability == @finding.mod_availability
                 %option{ :selected => "selected" } #{mod_availability}
               - else
@@ -1122,7 +1122,7 @@
         %label{ :class => "control-label", :for => "severity" } Severity
         .controls
           %select{ :name => "severity" }
-            - options.severity.each do |severity|
+            - settings.severity.each do |severity|
               - if severity == @finding.severity
                 %option{ :selected => "selected" } #{severity}
               - else
@@ -1138,7 +1138,7 @@
         %label{ :class => "control-label", :for => "likelihood" } Likelihood
         .controls
           %select{ :name => "likelihood" }
-            - options.likelihood.each do |likelihood|
+            - settings.likelihood.each do |likelihood|
               - if likelihood == @finding.likelihood
                 %option{ :selected => "selected" } #{likelihood}
               - else
@@ -1168,7 +1168,7 @@
       %label{ :class => "control-label", :for => "effort" } Remediation Effort
       .controls
         %select{ :name => "effort" }
-          - options.effort.each do |effort|
+          - settings.effort.each do |effort|
             - if effort == @finding.effort
               %option{ :selected => "selected" } #{effort}
             - else
@@ -1177,7 +1177,7 @@
       %label{ :class => "control-label", :for => "type" } Finding Type
       .controls
         %select{ :name => "type" }
-          - options.finding_types.each do |type|
+          - settings.finding_types.each do |type|
             - if type == @finding.type
               %option{ :selected => "selected" } #{type}
             - else

--- a/views/findings_list.haml
+++ b/views/findings_list.haml
@@ -25,7 +25,7 @@
                 });
               %br
               &nbsp;
-              - options.finding_types.each do |type|
+              - settings.finding_types.each do |type|
                 %tr
                   %td{:colspan => "3"}
                     %b


### PR DESCRIPTION
I looked at the Serpico log file after our last update and noticed that it was full of warnings making it unreadable.
![image](https://user-images.githubusercontent.com/3847037/31095923-73174a62-a788-11e7-9eef-29fa7b7c3b3c.png)

I found where the warnings were coming from and changed it to remove the warnings (and avoid problems in the long run when we want to update Sinatra)