### PR TITLE
CVSS Summary while creating / editing findings

### DIFF
--- a/helpers/helper.rb
+++ b/helpers/helper.rb
@@ -396,7 +396,7 @@ def cvss(data, is_cvssv3)
 	if av == "local"
 	    cvss_av = 0.395
 		c2_vs += "AV:L/"
-	elsif av == "local network"
+	elsif av == "adjacent network"
 	    cvss_av = 0.646
 		c2_vs += "AV:A/"
 	else

--- a/public/js/cvss.js
+++ b/public/js/cvss.js
@@ -35,17 +35,17 @@ Usage:
     <div id="cvssboard"></div>
 
     // create a new instance of CVSS calculator:
-    var c = new CVSS("cvssboard");
+    var c = new CVSS.js("cvssboard");
 
     // create a new instance of CVSS calculator with some event handler callbacks
-    var c = new CVSS("cvssboard", {
+    var c = new CVSS.js("cvssboard", {
                 onchange: function() {....} //optional
                 onsubmit: function() {....} //optional
                 }
-                
+
     // set a vector
     c.set('AV:L/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:L');
-    
+
     //get the value
     c.get() returns an object like:
 
@@ -53,9 +53,10 @@ Usage:
         score: 4.3,
         vector: 'AV:L/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:L'
     }
-    
+
 */
 
+var CVSS = CVSS || {};
 var CVSS = function (id, options) {
     this.options = options;
     this.wId = id;
@@ -160,7 +161,7 @@ var CVSS = function (id, options) {
             }
         }
     };
-    
+
     this.bme = {};
     this.bmgReg = {
         AV: 'LAN',
@@ -176,7 +177,7 @@ var CVSS = function (id, options) {
         C: 'C',
         I: 'C',
         A: 'C'
-    };    
+    };
     var s, f, dl, g, dd, l;
     this.el = document.getElementById(id);
     this.el.appendChild(s = e('style'));
@@ -227,10 +228,10 @@ var CVSS = function (id, options) {
     l.appendChild(this.vector = e('a'));
     this.vector.className = 'vector';
     this.vector.innerHTML = 'CVSS:2.0/AV:_/AC:_/AU:_/C:_/I:_/A:_';
-    
+
 };
 
-CVSS.prototype.severityRatings = [{
+CVSS.js.prototype.severityRatings = [{
     name: "None",
     bottom: 0.0,
     top: 0.0
@@ -252,7 +253,7 @@ CVSS.prototype.severityRatings = [{
     top: 10.0
 }];
 
-CVSS.prototype.severityRating = function (score) {
+CVSS.js.prototype.severityRating = function (score) {
     var i;
     var severityRatingLength = this.severityRatings.length;
     for (i = 0; i < severityRatingLength; i++) {
@@ -267,19 +268,19 @@ CVSS.prototype.severityRating = function (score) {
     };
 };
 
-CVSS.prototype.calculate = function () {
+CVSS.js.prototype.calculate = function () {
     // calculate is disabled is CVSSv2
     return '';
 };
 
-CVSS.prototype.get = function() {
+CVSS.js.prototype.get = function() {
     return {
         score: this.score.innerHTML,
         vector: this.vector.innerHTML
     }
 };
 
-CVSS.prototype.setMetric = function(a) {
+CVSS.js.prototype.setMetric = function(a) {
     var vectorString = this.vector.innerHTML;
     if (/AV:.\/AC:.\/AU:.\/C:.\/I:.\/A:./.test(vectorString)) {} else {
         vectorString = 'AV:_/AC:_/AU:_/C:_/I:_/A:_';
@@ -289,7 +290,7 @@ CVSS.prototype.setMetric = function(a) {
     this.set(newVec);
 };
 
-CVSS.prototype.set = function(vec) {
+CVSS.js.prototype.set = function(vec) {
     var newVec = 'CVSS:2.0/';
     sep = '';
     for (m in this.bm) {
@@ -312,7 +313,7 @@ CVSS.prototype.set = function(vec) {
     this.update(newVec);
 };
 
-CVSS.prototype.update = function(newVec) {
+CVSS.js.prototype.update = function(newVec) {
     this.vector.innerHTML = newVec;
     var s = this.calculate();
     //this.score.innerHTML = "CALC";

--- a/public/js/cvss.js
+++ b/public/js/cvss.js
@@ -57,7 +57,7 @@ Usage:
 */
 
 var CVSS = CVSS || {};
-var CVSS = function (id, options) {
+CVSS.js = function (id, options) {
     this.options = options;
     this.wId = id;
     var e = function (tag) {

--- a/public/js/cvss3.js
+++ b/public/js/cvss3.js
@@ -31,17 +31,15 @@ Usage:
     <div id="cvssboard"></div>
 
     // create a new instance of CVSS calculator:
-    var c = new CVSS("cvssboard");
+    var c = new CVSS.js("cvssboard");
 
     // create a new instance of CVSS calculator with some event handler callbacks
-    var c = new CVSS("cvssboard", {
+    var c = new CVSS.js("cvssboard", {
                 onchange: function() {....} //optional
                 onsubmit: function() {....} //optional
                 }
-                
     // set a vector
     c.set('AV:L/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:L');
-    
     //get the value
     c.get() returns an object like:
 
@@ -49,10 +47,10 @@ Usage:
         score: 4.3,
         vector: 'AV:L/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:L'
     }
-    
 */
 
-var CVSS = function (id, options) {
+var CVSS = CVSS || {};
+CVSS.js = function (id, options) {
     this.options = options;
     this.wId = id;
     var e = function (tag) {
@@ -179,7 +177,6 @@ var CVSS = function (id, options) {
             }
         }
     };
-    
     this.bme = {};
     this.bmgReg = {
         AV: 'NALP',
@@ -197,7 +194,7 @@ var CVSS = function (id, options) {
         C: 'C',
         I: 'C',
         A: 'C'
-    };    
+    };
     var s, f, dl, g, dd, l;
     this.el = document.getElementById(id);
     this.el.appendChild(s = e('style'));
@@ -249,7 +246,6 @@ var CVSS = function (id, options) {
     l.appendChild(this.vector = e('a'));
     this.vector.className = 'vector';
     this.vector.innerHTML = 'CVSS:3.0/AV:_/AC:_/PR:_/UI:_/S:_/C:_/I:_/A:_';
-    
     if (options.onsubmit) {
         f.appendChild(e('hr'));
         this.submitButton = f.appendChild(e('input'));
@@ -258,7 +254,7 @@ var CVSS = function (id, options) {
     }
 };
 
-CVSS.prototype.severityRatings = [{
+CVSS.js.prototype.severityRatings = [{
     name: "None",
     bottom: 0.0,
     top: 0.0
@@ -280,7 +276,7 @@ CVSS.prototype.severityRatings = [{
     top: 10.0
 }];
 
-CVSS.prototype.severityRating = function (score) {
+CVSS.js.prototype.severityRating = function (score) {
     var i;
     var severityRatingLength = this.severityRatings.length;
     for (i = 0; i < severityRatingLength; i++) {
@@ -295,7 +291,7 @@ CVSS.prototype.severityRating = function (score) {
     };
 };
 
-CVSS.prototype.calculate = function () {
+CVSS.js.prototype.calculate = function () {
     var cvssVersion = "3.0";
     var exploitabilityCoefficient = 8.22;
     var scopeCoefficient = 1.08;
@@ -399,14 +395,14 @@ CVSS.prototype.calculate = function () {
     }
 };
 
-CVSS.prototype.get = function() {
+CVSS.js.prototype.get = function() {
     return {
         score: this.score.innerHTML,
         vector: this.vector.innerHTML
     }
 };
 
-CVSS.prototype.setMetric = function(a) {
+CVSS.js.prototype.setMetric = function(a) {
     var vectorString = this.vector.innerHTML;
     if (/AV:.\/AC:.\/PR:.\/UI:.\/S:.\/C:.\/I:.\/A:./.test(vectorString)) {} else {
         vectorString = 'AV:_/AC:_/PR:_/UI:_/S:_/C:_/I:_/A:_';
@@ -416,7 +412,7 @@ CVSS.prototype.setMetric = function(a) {
     this.set(newVec);
 };
 
-CVSS.prototype.set = function(vec) {
+CVSS.js.prototype.set = function(vec) {
     var newVec = 'CVSS:3.0/';
     sep = '';
     for (m in this.bm) {
@@ -439,7 +435,7 @@ CVSS.prototype.set = function(vec) {
     this.update(newVec);
 };
 
-CVSS.prototype.update = function(newVec) {
+CVSS.js.prototype.update = function(newVec) {
     this.vector.innerHTML = newVec;
     var s = this.calculate();
     this.score.innerHTML = s;

--- a/public/js/cvsscalc20.js
+++ b/public/js/cvsscalc20.js
@@ -19,13 +19,16 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* This JavaScript contains two main functions. Both take CVSS metric values and calculate CVSS scores for Base,
- * Temporal and Environmental metric groups, their associated severity ratings, and an overall Vector String.
+/* This JavaScript is a modified version of the original cvsscalc30.js from FIRST
+ * It was modified to calculate CVSS V2 instead of CVSS V3.
  *
  * Use CVSS.calculateCVSSFromMetrics if you wish to pass metric values as individual parameters.
  * Use CVSS.calculateCVSSFromVector if you wish to pass metric values as a single Vector String.
  *
  * Changelog
+ *
+ * 2017-10-06  Maxime Nadeau  Changed the file to calculate CVSS V2 instead of CVSS V3.
+ *
  *
  * 2015-08-04  Darius Wiles   Added CVSS.generateXMLFromMetrics and CVSS.generateXMLFromVector functions to return
  *                            XML string representations of: a set of metric values; or a Vector String respectively.
@@ -61,7 +64,7 @@ CVSS.exploitabilityCoefficient = 20.;
 CVSS.vectorStringRegex_20 = /^CVSS:2\.0\/((AV:[NAL]|AC:[HML]|AU:[MSN]|[CIA]:[NPC]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|CDP:([XNLH]|LM|MH)|TD:[XNLMH]|[CIA]R:[XLMH])\/)*(AV:[NAL]|AC:[HML]|AU:[MSN]|[CIA]:[NPC]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|CDP:([XNLH]|LM|MH)|TD:[XNLMH]|[CIA]R:[XLMH])$/;
 
 
-// Associative arrays mapping each metric value to the constant defined in the CVSS scoring formula in the CVSS v3.0
+// Associative arrays mapping each metric value to the constant defined in the CVSS scoring formula in the CVSS v2.0
 // specification.
 
 CVSS.Weight = {
@@ -81,13 +84,11 @@ CVSS.Weight = {
 };
 
 
-// Severity rating bands, as defined in the CVSS v3.0 specification.
+// Severity rating bands, as defined in the CVSS v2.0 specification.
 
-CVSS.severityRatings  = [ { name: "None",     bottom: 0.0, top:  0.0},
-                          { name: "Low",      bottom: 0.1, top:  3.9},
+CVSS.severityRatings  = [ { name: "Low",      bottom: 0.0, top:  3.9},
                           { name: "Medium",   bottom: 4.0, top:  6.9},
-                          { name: "High",     bottom: 7.0, top:  8.9},
-                          { name: "Critical", bottom: 9.0, top: 10.0} ];
+                          { name: "High",     bottom: 7.0, top:  10.0} ];
 
 
 
@@ -95,7 +96,7 @@ CVSS.severityRatings  = [ { name: "None",     bottom: 0.0, top:  0.0},
 /* ** CVSS.calculateCVSSFromMetrics **
  *
  * Takes Base, Temporal and Environmental metric values as individual parameters. Their values are in the short format
- * defined in the CVSS v3.0 standard definition of the Vector String. For example, the AttackComplexity parameter
+ * defined in the CVSS v2.0 standard definition of the Vector String. For example, the AttackComplexity parameter
  * should be either "H" or "L".
  *
  * Returns Base, Temporal and Environmental scores, severity ratings, and an overall Vector String. All Base metrics
@@ -116,7 +117,7 @@ CVSS.severityRatings  = [ { name: "None",     bottom: 0.0, top:  0.0},
  *                 "MissingBaseMetric", if at least one Base metric has not been defined; or
  *                 "UnknownMetricValue", if at least one metric value is invalid.
  *   errorMetrics - an array of strings representing the metrics at fault. The strings are abbreviated versions of the
- *                  metrics, as defined in the CVSS v3.0 standard definition of the Vector String.
+ *                  metrics, as defined in the CVSS v2.0 standard definition of the Vector String.
  */
 CVSS.calculateCVSSFromMetrics = function (
   AttackVector, AttackComplexity, Authentication, Confidentiality, Integrity, Availability,
@@ -301,7 +302,7 @@ CVSS.calculateCVSSFromMetrics = function (
 /* ** CVSS.calculateCVSSFromVector **
  *
  * Takes Base, Temporal and Environmental metric values as a single string in the Vector String format defined
- * in the CVSS v3.0 standard definition of the Vector String.
+ * in the CVSS v2.0 standard definition of the Vector String.
  *
  * Returns Base, Temporal and Environmental scores, severity ratings, and an overall Vector String. All Base metrics
  * are required to generate this output. All Temporal and Environmental metric values are optional. Any that are not

--- a/public/js/cvsscalc20.js
+++ b/public/js/cvsscalc20.js
@@ -1,0 +1,402 @@
+/* Copyright (c) 2015, FIRST.ORG, INC.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ *    following disclaimer in the documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+ *    products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* This JavaScript contains two main functions. Both take CVSS metric values and calculate CVSS scores for Base,
+ * Temporal and Environmental metric groups, their associated severity ratings, and an overall Vector String.
+ *
+ * Use CVSS.calculateCVSSFromMetrics if you wish to pass metric values as individual parameters.
+ * Use CVSS.calculateCVSSFromVector if you wish to pass metric values as a single Vector String.
+ *
+ * Changelog
+ *
+ * 2015-08-04  Darius Wiles   Added CVSS.generateXMLFromMetrics and CVSS.generateXMLFromVector functions to return
+ *                            XML string representations of: a set of metric values; or a Vector String respectively.
+ *                            Moved all constants and functions to an object named "CVSS" to
+ *                            reduce the chance of conflicts in global variables when this file is combined with
+ *                            other JavaScript code. This will break all existing code that uses this file until
+ *                            the string "CVSS." is prepended to all references. The "Exploitability" metric has been
+ *                            renamed "Exploit Code Maturity" in the specification, so the same change has been made
+ *                            in the code in this file.
+ *
+ * 2015-04-24  Darius Wiles   Environmental formula modified to eliminate undesirable behavior caused by subtle
+ *                            differences in rounding between Temporal and Environmental formulas that often
+ *                            caused the latter to be 0.1 lower than than the former when all Environmental
+ *                            metrics are "Not defined". Also added a RoundUp1 function to simplify formulas.
+ *
+ * 2015-04-09  Darius Wiles   Added calculateCVSSFromVector function, license information, cleaned up code and improved
+ *                            comments.
+ *
+ * 2014-12-12  Darius Wiles   Initial release for CVSS 3.0 Preview 2.
+ */
+
+// Constants used in the formula. They are not declared as "const" to avoid problems in older browsers.
+
+var CVSS = {};
+
+CVSS.CVSSVersionIdentifier = "CVSS:2.0";
+CVSS.impactCoefficient = 10.41;
+CVSS.exploitabilityCoefficient = 20.;
+
+// A regular expression to validate that a CVSS 2.0 vector string is well formed. It checks metrics and metric
+// values. It does not check that a metric is specified more than once and it does not check that all base
+// metrics are present. These checks need to be performed separately.
+CVSS.vectorStringRegex_20 = /^CVSS:2\.0\/((AV:[NAL]|AC:[HML]|AU:[MSN]|[CIA]:[NPC]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|CDP:([XNLH]|LM|MH)|TD:[XNLMH]|[CIA]R:[XLMH])\/)*(AV:[NAL]|AC:[HML]|AU:[MSN]|[CIA]:[NPC]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|CDP:([XNLH]|LM|MH)|TD:[XNLMH]|[CIA]R:[XLMH])$/;
+
+
+// Associative arrays mapping each metric value to the constant defined in the CVSS scoring formula in the CVSS v3.0
+// specification.
+
+CVSS.Weight = {
+  AV:   { N: 1.,    A: 0.646,  L: 0.395},
+  AC:   { H: 0.35,  M: 0.61,   L: 0.71},
+  AU:   { M: 0.45,  S: 0.56,   N: 0.704},
+  CIA:  { N: 0.,    P: 0.275,  C: 0.660},                   // C, I and A have the same weights
+
+  E:    { X: 1.,     U: 0.85,   P: 0.90,  F: 0.95,  H: 1.},
+  RL:   { X: 1.,     O: 0.87,   T: 0.90,  W: 0.95,  U: 1.},
+  RC:   { X: 1.,     U: 0.90,   R: 0.95,  C: 1.},
+
+  CDP:  { X: 0.,     N: 0.,     L: 0.1,   LM: 0.3,  MH: 0.4,  H: 0.5 },
+  TD:   { X: 1.,     N: 0.,     L: 0.25,  M: 0.75,  H: 1. },
+
+  CIAR: { X: 1.,     L: 0.5,    M: 1.,     H: 1.51}           // CR, IR and AR have the same weights
+};
+
+
+// Severity rating bands, as defined in the CVSS v3.0 specification.
+
+CVSS.severityRatings  = [ { name: "None",     bottom: 0.0, top:  0.0},
+                          { name: "Low",      bottom: 0.1, top:  3.9},
+                          { name: "Medium",   bottom: 4.0, top:  6.9},
+                          { name: "High",     bottom: 7.0, top:  8.9},
+                          { name: "Critical", bottom: 9.0, top: 10.0} ];
+
+
+
+
+/* ** CVSS.calculateCVSSFromMetrics **
+ *
+ * Takes Base, Temporal and Environmental metric values as individual parameters. Their values are in the short format
+ * defined in the CVSS v3.0 standard definition of the Vector String. For example, the AttackComplexity parameter
+ * should be either "H" or "L".
+ *
+ * Returns Base, Temporal and Environmental scores, severity ratings, and an overall Vector String. All Base metrics
+ * are required to generate this output. All Temporal and Environmental metric values are optional. Any that are not
+ * passed default to "X" ("Not Defined").
+ *
+ * The output is an object which always has a property named "success".
+ *
+ * If no errors are encountered, success is Boolean "true", and the following other properties are defined containing
+ * scores, severities and a vector string:
+ *   baseMetricScore, baseSeverity,
+ *   temporalMetricScore, temporalSeverity,
+ *   environmentalMetricScore, environmentalSeverity,
+ *   vectorString
+ *
+ * If errors are encountered, success is Boolean "false", and the following other properties are defined:
+ *   errorType - a string indicating the error. Either:
+ *                 "MissingBaseMetric", if at least one Base metric has not been defined; or
+ *                 "UnknownMetricValue", if at least one metric value is invalid.
+ *   errorMetrics - an array of strings representing the metrics at fault. The strings are abbreviated versions of the
+ *                  metrics, as defined in the CVSS v3.0 standard definition of the Vector String.
+ */
+CVSS.calculateCVSSFromMetrics = function (
+  AttackVector, AttackComplexity, Authentication, Confidentiality, Integrity, Availability,
+  Exploitability, RemediationLevel, ReportConfidence,
+  IntegrityRequirement, ConfidentialityRequirement, AvailabilityRequirement,
+  CollateralDamagePotential, TargetDistribution) {
+
+  // If input validation fails, this array is populated with strings indicating which metrics failed validation.
+  var badMetrics = [];
+
+  // ENSURE ALL BASE METRICS ARE DEFINED
+  //
+  // We need values for all Base Score metrics to calculate scores.
+  // If any Base Score parameters are undefined, create an array of missing metrics and return it with an error.
+
+  if (typeof AttackVector       === "undefined" || AttackVector       === "") { badMetrics.push("AV"); }
+  if (typeof AttackComplexity   === "undefined" || AttackComplexity   === "") { badMetrics.push("AC"); }
+  if (typeof Authentication     === "undefined" || Authentication     === "") { badMetrics.push("AU"); }
+  if (typeof Confidentiality    === "undefined" || Confidentiality    === "") { badMetrics.push("C");  }
+  if (typeof Integrity          === "undefined" || Integrity          === "") { badMetrics.push("I");  }
+  if (typeof Availability       === "undefined" || Availability       === "") { badMetrics.push("A");  }
+
+  if (badMetrics.length > 0) {
+    return { success: false, errorType: "MissingBaseMetric", errorMetrics: badMetrics };
+  }
+
+
+  // STORE THE METRIC VALUES THAT WERE PASSED AS PARAMETERS
+  //
+  // Temporal and Environmental metrics are optional, so set them to "X" ("Not Defined") if no value was passed.
+
+  var AV = AttackVector;
+  var AC = AttackComplexity;
+  var AU = Authentication;
+  var C  = Confidentiality;
+  var I  = Integrity;
+  var A  = Availability;
+
+  var E =   Exploitability      || "X";
+  var RL =  RemediationLevel    || "X";
+  var RC =  ReportConfidence    || "X";
+
+  var CDP = CollateralDamagePotential  || "X";
+  var TD = TargetDistribution          || "X";
+
+  var CR =  ConfidentialityRequirement || "X";
+  var IR =  IntegrityRequirement       || "X";
+  var AR =  AvailabilityRequirement    || "X";
+
+  // CHECK VALIDITY OF METRIC VALUES
+  //
+  // Use the Weight object to ensure that, for every metric, the metric value passed is valid.
+  // If any invalid values are found, create an array of their metrics and return it with an error.
+  //
+  // The Privileges Required (PR) weight depends on Scope, but when checking the validity of PR we must not assume
+  // that the given value for Scope is valid. We therefore always look at the weights for Unchanged Scope when
+  // performing this check. The same applies for validation of Modified Privileges Required (MPR).
+  //
+  // The Weights object does not contain "X" ("Not Defined") values for Environmental metrics because we replace them
+  // with their Base metric equivalents later in the function. For example, an MAV of "X" will be replaced with the
+  // value given for AV. We therefore need to explicitly allow a value of "X" for Environmental metrics.
+
+  if (!CVSS.Weight.AV.hasOwnProperty(AV))   { badMetrics.push("AV"); }
+  if (!CVSS.Weight.AC.hasOwnProperty(AC))   { badMetrics.push("AC"); }
+  if (!CVSS.Weight.AU.hasOwnProperty(AU))   { badMetrics.push("AU"); }
+  if (!CVSS.Weight.CIA.hasOwnProperty(C))   { badMetrics.push("C"); }
+  if (!CVSS.Weight.CIA.hasOwnProperty(I))   { badMetrics.push("I"); }
+  if (!CVSS.Weight.CIA.hasOwnProperty(A))   { badMetrics.push("A"); }
+
+  if (!CVSS.Weight.E.hasOwnProperty(E))     { badMetrics.push("E"); }
+  if (!CVSS.Weight.RL.hasOwnProperty(RL))   { badMetrics.push("RL"); }
+  if (!CVSS.Weight.RC.hasOwnProperty(RC))   { badMetrics.push("RC"); }
+
+  if (!(CDP === "X"  || CVSS.Weight.CDP.hasOwnProperty(CDP))) { badMetrics.push("CDP"); }
+  if (!(TD  === "X"  || CVSS.Weight.TD.hasOwnProperty(MAC)))  { badMetrics.push("TD"); }
+
+  if (!(CR  === "X" || CVSS.Weight.CIAR.hasOwnProperty(CR)))  { badMetrics.push("CR"); }
+  if (!(IR  === "X" || CVSS.Weight.CIAR.hasOwnProperty(IR)))  { badMetrics.push("IR"); }
+  if (!(AR  === "X" || CVSS.Weight.CIAR.hasOwnProperty(AR)))  { badMetrics.push("AR"); }
+
+  if (badMetrics.length > 0) {
+    return { success: false, errorType: "UnknownMetricValue", errorMetrics: badMetrics };
+  }
+
+
+
+  // GATHER WEIGHTS FOR ALL METRICS
+
+  var metricWeightAV  = CVSS.Weight.AV    [AV];
+  var metricWeightAC  = CVSS.Weight.AC    [AC];
+  var metricWeightAU  = CVSS.Weight.AU    [AU];
+  var metricWeightC   = CVSS.Weight.CIA   [C];
+  var metricWeightI   = CVSS.Weight.CIA   [I];
+  var metricWeightA   = CVSS.Weight.CIA   [A];
+
+  var metricWeightE   = CVSS.Weight.E     [E];
+  var metricWeightRL  = CVSS.Weight.RL    [RL];
+  var metricWeightRC  = CVSS.Weight.RC    [RC];
+
+  var metricWeightCDP = CVSS.Weight.CDP   [CDP];
+  var metricWeightTD  = CVSS.Weight.TD    [TD];
+
+  // For metrics that are modified versions of Base Score metrics, e.g. Modified Attack Vector, use the value of
+  // the Base Score metric if the modified version value is "X" ("Not Defined").
+  var metricWeightCR  = CVSS.Weight.CIAR  [CR];
+  var metricWeightIR  = CVSS.Weight.CIAR  [IR];
+  var metricWeightAR  = CVSS.Weight.CIAR  [AR];
+
+
+  // CALCULATE THE CVSS BASE SCORE
+  var baseScore;
+  var impactSubScore = CVSS.impactCoefficient * (1 - (1 - metricWeightC) * (1 - metricWeightI) * (1 - metricWeightA));
+  var exploitabalitySubScore = CVSS.exploitabilityCoefficient * metricWeightAC * metricWeightAV * metricWeightAU;
+
+  var impactF = 0.;
+  if (impactSubScore != 0) {
+    impactF = 1.176;
+  }
+
+  baseScore = CVSS.roundToOneDecimal((0.6 * impactSubScore + 0.4 * exploitabalitySubScore - 1.5) * impactF)
+
+  // CALCULATE THE CVSS TEMPORAL SCORE
+  var temporalScore = CVSS.roundToOneDecimal(baseScore * metricWeightE * metricWeightRL * metricWeightRC)
+
+  // CALCULATE THE CVSS ENVIRONMENTAL SCORE
+  var envScore;
+  var envModifiedImpactSubScore = Math.min(CVSS.impactCoefficient * (1 - (1 - metricWeightC * metricWeightCR) * (1 - metricWeightI * metricWeightIR) * (1 - metricWeightA * metricWeightAR)), 10);
+
+  var modifiedImpactF = 0.;
+  if (envModifiedImpactSubScore != 0) {
+      modifiedImpactF = 1.176
+  }
+
+  var modifiedBase = CVSS.roundToOneDecimal((0.6 * envModifiedImpactSubScore + 0.4 * exploitabalitySubScore - 1.5) * modifiedImpactF)
+  var adjustedTemporal = modifiedBase * metricWeightE * metricWeightRL * metricWeightRC;
+  envScore = CVSS.roundToOneDecimal((adjustedTemporal + (10. - adjustedTemporal) * metricWeightCDP) * metricWeightTD)
+
+
+  // CONSTRUCT THE VECTOR STRING
+
+  var vectorString =
+    CVSS.CVSSVersionIdentifier +
+    "/AV:" + AV +
+    "/AC:" + AC +
+    "/AU:" + AU +
+    "/C:"  + C +
+    "/I:"  + I +
+    "/A:"  + A;
+
+  if (E  !== "X")  {vectorString = vectorString + "/E:" + E;}
+  if (RL !== "X")  {vectorString = vectorString + "/RL:" + RL;}
+  if (RC !== "X")  {vectorString = vectorString + "/RC:" + RC;}
+
+  if (CDP !== "X") {vectorString = vectorString + "/CDP:" + CDP;}
+  if (TD !== "X") {vectorString = vectorString + "/TD:" + TD;}
+
+  if (CR  !== "X") {vectorString = vectorString + "/CR:" + CR;}
+  if (IR  !== "X") {vectorString = vectorString + "/IR:"  + IR;}
+  if (AR  !== "X") {vectorString = vectorString + "/AR:"  + AR;}
+
+
+  // Return an object containing the scores for all three metric groups, and an overall vector string.
+
+  return {
+    success: true,
+    baseMetricScore: baseScore.toFixed(1),
+    baseSeverity: CVSS.severityRating( baseScore.toFixed(1) ),
+
+    temporalMetricScore: temporalScore.toFixed(1),
+    temporalSeverity: CVSS.severityRating( temporalScore.toFixed(1) ),
+
+    environmentalMetricScore: envScore.toFixed(1),
+    environmentalSeverity: CVSS.severityRating( envScore.toFixed(1) ),
+
+    vectorString: vectorString
+  };
+};
+
+
+
+
+/* ** CVSS.calculateCVSSFromVector **
+ *
+ * Takes Base, Temporal and Environmental metric values as a single string in the Vector String format defined
+ * in the CVSS v3.0 standard definition of the Vector String.
+ *
+ * Returns Base, Temporal and Environmental scores, severity ratings, and an overall Vector String. All Base metrics
+ * are required to generate this output. All Temporal and Environmental metric values are optional. Any that are not
+ * passed default to "X" ("Not Defined").
+ *
+ * See the comment for the CVSS.calculateCVSSFromMetrics function for details on the function output. In addition to
+ * the error conditions listed for that function, this function can also return:
+ *   "MalformedVectorString", if the Vector String passed is does not conform to the format in the standard; or
+ *   "MultipleDefinitionsOfMetric", if the Vector String is well formed but defines the same metric (or metrics),
+ *                                  more than once.
+ */
+CVSS.calculateCVSSFromVector = function ( vectorString ) {
+
+  var metricValues = {
+    AV:  undefined, AC:  undefined, AU:  undefined,
+    C:   undefined, I:   undefined, A:   undefined,
+    E:   undefined, RL:  undefined, RC:  undefined,
+    CR:  undefined, IR:  undefined, AR:  undefined,
+    CDP: undefined, TD: undefined
+  };
+
+  // If input validation fails, this array is populated with strings indicating which metrics failed validation.
+  var badMetrics = [];
+
+  if (!CVSS.vectorStringRegex_20.test(vectorString)) {
+    return { success: false, errorType: "MalformedVectorString" };
+  }
+
+  var metricNameValue = vectorString.substring(CVSS.CVSSVersionIdentifier.length).split("/");
+
+  for (var i in metricNameValue) {
+    if (metricNameValue.hasOwnProperty(i)) {
+
+      var singleMetric = metricNameValue[i].split(":");
+
+      if (typeof metricValues[singleMetric[0]] === "undefined") {
+        metricValues[singleMetric[0]] = singleMetric[1];
+      } else {
+        badMetrics.push(singleMetric[0]);
+      }
+    }
+  }
+
+  if (badMetrics.length > 0) {
+    return { success: false, errorType: "MultipleDefinitionsOfMetric", errorMetrics: badMetrics };
+  }
+
+  return CVSS.calculateCVSSFromMetrics (
+    metricValues.AV,  metricValues.AC,  metricValues.AU,
+    metricValues.C,   metricValues.I,   metricValues.A,
+    metricValues.E,   metricValues.RL,  metricValues.RC,
+    metricValues.CR,  metricValues.IR,  metricValues.AR,
+    metricValues.CDP, metricValues.TD);
+};
+
+
+
+
+/* ** CVSS.roundUp1 **
+ *
+ * Rounds up the number passed as a parameter to 1 decimal place and returns the result.
+ *
+ * Standard JavaScript errors thrown when arithmetic operations are performed on non-numbers will be returned if the
+ * given input is not a number.
+ */
+CVSS.roundToOneDecimal = function (d) {
+  return Math.round(d * 10) / 10;
+};
+
+
+
+
+/* ** CVSS.severityRating **
+ *
+ * Given a CVSS score, returns the name of the severity rating as defined in the CVSS standard.
+ * The input needs to be a number between 0.0 to 10.0, to one decimal place of precision.
+ *
+ * The following error values may be returned instead of a severity rating name:
+ *   NaN (JavaScript "Not a Number") - if the input is not a number.
+ *   undefined - if the input is a number that is not within the range of any defined severity rating.
+ */
+CVSS.severityRating = function (score) {
+  var severityRatingLength = CVSS.severityRatings.length;
+
+  var validatedScore = Number(score);
+
+  if (isNaN(validatedScore)) {
+    return validatedScore;
+  }
+
+  for (var i = 0; i < severityRatingLength; i++) {
+    if (score >= CVSS.severityRatings[i].bottom && score <= CVSS.severityRatings[i].top) {
+      return CVSS.severityRatings[i].name;
+    }
+  }
+
+  return undefined;
+};

--- a/server.rb
+++ b/server.rb
@@ -44,7 +44,7 @@ class Server < Sinatra::Application
     end
 
     # CVSS
-    set :av, ["Local","Local Network","Network"]
+    set :av, ["Local","Adjacent Network","Network"]
     set :ac, ["High","Medium","Low"]
     set :au, ["Multiple","Single","None"]
     set :c, ["None","Partial","Complete"]

--- a/views/create_finding.haml
+++ b/views/create_finding.haml
@@ -1,16 +1,16 @@
-%link{:href => "/css/bootstrap-suggest.css", :rel => "stylesheet"}/
-%script{:src => "/js/bootstrap-suggest.js"}
+%link{ :href => "/css/bootstrap-suggest.css", :rel => "stylesheet" }/
+%script{ :src => "/js/bootstrap-suggest.js" }
 
 .span10
   %br
   %h2 New Finding
   %br
   %br
-  %form{ :class => "form-horizontal", :method => 'post', :enctype => 'application/x-www-form-urlencoded'}
+  %form.form-horizontal{ :method => "post", :enctype => "application/x-www-form-urlencoded" }
     .control-group
       %label.control-label{ :for => "title" } Title
       .controls
-        %input{ :type => 'text', :name => 'title', :value => ""}
+        %input{ :type => "text", :name => "title", :value => "" }
     - if !@master
       .control-group
         %label.control-label{ :for => "assessment_type" } Assessment Type
@@ -28,33 +28,33 @@
       .control-group
         %label.control-label{ :for => "pluginid" } Add new nessus ID mapping
         .controls
-          %input{ :type => 'text', :name => 'pluginid'}
+          %input{ :type => "text", :name => "pluginid" }
     - if @vulnmap
       .control-group
         %label.control-label{ :for => "msf_ref" } Add new Vuln ID mapping
         .controls
-          %input{ :type => 'text', :name => 'msf_ref'}
+          %input{ :type => "text", :name => "msf_ref" }
     - if @dread
       .control-group
         %label.control-label{ :for => "damage" } Damage
         .controls
-          %input{ :type => 'number', :min => '0', :max => '10', :name => 'damage', :value => "0", :required => true}
+          %input{ :type => "number", :min => "0", :max => "10", :name => "damage", :value => "0", :required => true }
       .control-group
         %label.control-label{ :for => "reproducability" } Reproducibility
         .controls
-          %input{ :type => 'number', :min => '0', :max => '10', :name => 'reproducability', :value => "0", :required => true}
+          %input{ :type => "number", :min => "0", :max => "10", :name => "reproducability", :value => "0", :required => true }
       .control-group
         %label.control-label{ :for => "exploitability" } Exploitability
         .controls
-          %input{ :type => 'number', :min => '0', :max => '10', :name => 'exploitability', :value => "0", :required => true}
+          %input{ :type => "number", :min => "0", :max => "10", :name => "exploitability", :value => "0", :required => true }
       .control-group
         %label.control-label{ :for => "affected_users" } Affected Users
         .controls
-          %input{ :type => 'number', :min => '0', :max => '10', :name => 'affected_users', :value => "0", :required => true}
+          %input{ :type => "number", :min => "0", :max => "10", :name => "affected_users", :value => "0", :required => true }
       .control-group
         %label.control-label{ :for => "discoverability" } Discoverability
         .controls
-          %input{ :type => 'number', :min => '0', :max => '10', :name => 'discoverability', :value => "0", :required => true}
+          %input{ :type => "number", :min => "0", :max => "10", :name => "discoverability", :value => "0", :required => true }
       .control-group
         %label.control-label{ :for => "effort" } Remediation Effort
         .controls
@@ -65,599 +65,155 @@
     - elsif @cvss
       .control-group
         %label.control-label{ :for => "attack_vector" }
-          %a{:href=> '#mymodal', "data-toggle"=>'modal', :class=>'btn btn-info'}
+          %a.btn.btn-info{ :href=> "#mymodal", "data-toggle" => "modal" }
             CVSS Vector String
-        .modal{:id=>'mymodal', :class=>'modal hide fade', :tabindex=>'-1', :role=>'dialog', "aria-labelledby"=>'modal-label', "aria-hidden"=>'true'}
+        .controls
+          %input.form-control#vs{ :type => "text", :placeholder=> "CVSS Vector String", :style=> "width:35em" }
+        .modal.modal.hide.fade#mymodal{ :tabindex=> "-1", :role=> "dialog", "aria-labelledby" => "modal-label", "aria-hidden" => "true" }
           .modal-header
-            %button{:type=>'button', :class=>'close', "data-dismiss"=>"modal", "aria-hidden"=>"true"}
+            %button.close{ :type=> "button", "data-dismiss" => "modal", "aria-hidden" => "true" }
               x
-            %h3{:id=>"modal-label"}
+            %h3#modal-label
               CVSS Vector String
           .modal-body
-          .modal-body
-            %link{ :rel=>"stylesheet", :type=>"text/css", :media=>"all", :href=>"/css/cvss.css"}
-            %script{ :src => "/js/cvss.js"}
-            %div{ :id=>"cvssboard"}
-              %script
-                function updateDropdown(score){
-                var vector = score.trim().split("/");
-                for(var i in vector){
-                var part = vector[i];
-
-                if (part.length > 0){
-                part = part.toUpperCase();
-                }
-
-                // AV
-                if(part.includes("AV:")){
-                if(part.includes(":L")){
-                document.getElementById('av').selectedIndex=0;
-                }
-                if(part.includes(":A")){
-                document.getElementById('av').selectedIndex=1;
-                }
-                if(part.includes(":N")){
-                document.getElementById('av').selectedIndex=2;
-                }
-                }
-
-                // AC
-                if(part.includes("AC:")){
-                if(part.includes(":H")){
-                document.getElementById('ac').selectedIndex=0;
-                }
-                if(part.includes(":M")){
-                document.getElementById('ac').selectedIndex=1;
-                }
-                if(part.includes(":L")){
-                document.getElementById('ac').selectedIndex=2;
-                }
-                }
-
-                // AU
-                if(part.includes("AU:")){
-                if(part.includes(":M")){
-                document.getElementById('au').selectedIndex=0;
-                }
-                if(part.includes(":S")){
-                document.getElementById('au').selectedIndex=1;
-                }
-                if(part.includes(":N")){
-                document.getElementById('au').selectedIndex=2;
-                }
-                }
-
-                // C
-                if(part.includes("C:") && !part.includes("AC:")){
-                if(part.includes(":N")){
-                document.getElementById('c').selectedIndex=0;
-                }
-                if(part.includes(":P")){
-                document.getElementById('c').selectedIndex=1;
-                }
-                if(part.includes(":C")){
-                document.getElementById('c').selectedIndex=2;
-                }
-                }
-
-                // I
-                if(part.includes("I:")){
-                if(part.includes(":N")){
-                document.getElementById('i').selectedIndex=0;
-                }
-                if(part.includes(":P")){
-                document.getElementById('i').selectedIndex=1;
-                }
-                if(part.includes(":C")){
-                document.getElementById('i').selectedIndex=2;
-                }
-                }
-
-                // A
-                if(part.includes("A:")){
-                if(part.includes(":N")){
-                document.getElementById('a').selectedIndex=0;
-                }
-                if(part.includes(":P")){
-                document.getElementById('a').selectedIndex=1;
-                }
-                if(part.includes(":C")){
-                document.getElementById('a').selectedIndex=2;
-                }
-                }
-
-                // E
-                if(part.includes("E:")){
-                if(part.includes(":ND")){
-                document.getElementById('e').selectedIndex=0;
-                }
-                if(part.includes(":U")){
-                document.getElementById('e').selectedIndex=1;
-                }
-                if(part.includes(":POC")){
-                document.getElementById('e').selectedIndex=2;
-                }
-                if(part.includes(":F")){
-                document.getElementById('e').selectedIndex=3;
-                }
-                if(part.includes(":H")){
-                document.getElementById('e').selectedIndex=4;
-                }
-                }
-
-                // RL
-                if(part.includes("RL:")){
-                if(part.includes(":ND")){
-                document.getElementById('rl').selectedIndex=0;
-                }
-                if(part.includes(":OF")){
-                document.getElementById('rl').selectedIndex=1;
-                }
-                if(part.includes(":TF")){
-                document.getElementById('rl').selectedIndex=2;
-                }
-                if(part.includes(":W")){
-                document.getElementById('rl').selectedIndex=3;
-                }
-                if(part.includes(":U")){
-                document.getElementById('rl').selectedIndex=4;
-                }
-                }
-
-                // RC
-                if(part.includes("RC:")){
-                if(part.includes(":ND")){
-                document.getElementById('rc').selectedIndex=0;
-                }
-                if(part.includes(":UC")){
-                document.getElementById('rc').selectedIndex=1;
-                }
-                if(part.includes(":UR")){
-                document.getElementById('rc').selectedIndex=2;
-                }
-                if(part.includes(":C")){
-                document.getElementById('rc').selectedIndex=3;
-                }
-                }
-
-                // CDP
-                if(part.includes("CDP:")){
-                if(part.includes(":ND")){
-                document.getElementById('cdp').selectedIndex=0;
-                }
-                if(part.includes(":N")){
-                document.getElementById('cdp').selectedIndex=1;
-                }
-                if(part.includes(":LM")){
-                document.getElementById('cdp').selectedIndex=2;
-                }
-                if(part.includes(":MH")){
-                document.getElementById('cdp').selectedIndex=3;
-                }
-                if(part.includes(":H")){
-                document.getElementById('cdp').selectedIndex=4;
-                }
-                }
-
-                // TD
-                if(part.includes("TD:")){
-                if(part.includes(":ND")){
-                document.getElementById('td').selectedIndex=0;
-                }
-                if(part.includes(":N")){
-                document.getElementById('td').selectedIndex=1;
-                }
-                if(part.includes(":L")){
-                document.getElementById('td').selectedIndex=2;
-                }
-                if(part.includes(":M")){
-                document.getElementById('td').selectedIndex=3;
-                }
-                if(part.includes(":H")){
-                document.getElementById('td').selectedIndex=4;
-                }
-                }
-
-                // CD
-                if(part.includes("CR:")){
-                if(part.includes(":ND")){
-                document.getElementById('cd').selectedIndex=0;
-                }
-                if(part.includes(":L")){
-                document.getElementById('cd').selectedIndex=1;
-                }
-                if(part.includes(":M")){
-                document.getElementById('cd').selectedIndex=2;
-                }
-                if(part.includes(":H")){
-                document.getElementById('cd').selectedIndex=3;
-                }
-                }
-
-                // IR
-                if(part.includes("IR:")){
-                if(part.includes(":ND")){
-                document.getElementById('ir').selectedIndex=0;
-                }
-                if(part.includes(":L")){
-                document.getElementById('ir').selectedIndex=1;
-                }
-                if(part.includes(":M")){
-                document.getElementById('ir').selectedIndex=2;
-                }
-                if(part.includes(":H")){
-                document.getElementById('ir').selectedIndex=3;
-                }
-                }
-
-                // AR
-                if(part.includes("AR:")){
-                if(part.includes(":ND")){
-                document.getElementById('ar').selectedIndex=0;
-                }
-                if(part.includes(":L")){
-                document.getElementById('ar').selectedIndex=1;
-                }
-                if(part.includes(":M")){
-                document.getElementById('ar').selectedIndex=2;
-                }
-                if(part.includes(":H")){
-                document.getElementById('ar').selectedIndex=3;
-                }
-                }
-                }}
-                var c = new CVSS.js("cvssboard", {
-                onchange: function() {
-                window.location.hash = c.get().vector;
-                document.getElementById('vs').value = c.get().vector;
-                updateDropdown(c.get().vector);
-                }
-                });
-
-                $("#vs").on('change keydown paste input', function(){
-                updateDropdown(this.value);
-                });
+            %link{ :rel => "stylesheet", :type => "text/css", :media => "all", :href => "/css/cvss.css" }
+            %script{ :src => "/js/cvsscalc20.js" }
+            %script{ :src => "/js/cvss.js" }
+            %div#cvssboard
+      %span.input-group-btn
+      .control-group.cvss2
+        %label.control-label{ :for => "baseScore" } Base Score
         .controls
-          %input{:type => "text", :class=>"form-control", :placeholder=>"CVSS Vector String", :id=>"vs", :style=>"width:35em"}
-      .control-group
+          #baseScore.cvssjs
+            .results
+              %span.score
+              %span.severity
+      .control-group.cvss2
+        %label.control-label{ :for => "temporalScore" } Temporal Score
+        .controls
+          #temporalScore.cvssjs
+            .results
+              %span.score
+              %span.severity
+      .control-group.cvss2
+        %label.control-label{ :for => "environmentalScore" } Environmental Score
+        .controls
+          #environmentalScore.cvssjs
+            .results
+              %span.score
+              %span.severity
+
+      .control-group.cvss2
         %label.control-label{ :for => "av" } Access Vector
         .controls
-          %select{ :name => "av", :id => "av" }
+          %select#av{ :name => "av", "data-cvss-tag" => "AV" }
             %option Local
             %option Adjacent Network
             %option Network
-      .control-group
+      .control-group.cvss2
         %label.control-label{ :for => "ac" } Access Complexity
         .controls
-          %select{ :name => "ac", :id => "ac" }
+          %select#ac{ :name => "ac", "data-cvss-tag" => "AC" }
             %option High
             %option Medium
             %option Low
-      .control-group
+      .control-group.cvss2
         %label.control-label{ :for => "au" } Authentication
         .controls
-          %select{ :name => "au", :id => "au" }
+          %select#au{ :name => "au", "data-cvss-tag" => "AU" }
             %option Multiple
             %option Single
             %option None
-      .control-group
+      .control-group.cvss2
         %label.control-label{ :for => "c" } Confidentiality Impact
         .controls
-          %select{ :name => "c", :id => "c" }
+          %select#c{ :name => "c", "data-cvss-tag" => "C" }
             %option None
             %option Partial
             %option Complete
-      .control-group
+      .control-group.cvss2
         %label.control-label{ :for => "i" } Integrity Impact
         .controls
-          %select{ :name => "i", :id => "i" }
+          %select#i{ :name => "i", "data-cvss-tag" => "I" }
             %option None
             %option Partial
             %option Complete
-      .control-group
+      .control-group.cvss2
         %label.control-label{ :for => "a" } Availability Impact
         .controls
-          %select{ :name => "a", :id => "a" }
+          %select#a{ :name => "a", "data-cvss-tag" => "A" }
             %option None
             %option Partial
             %option Complete
-      .control-group
+      .control-group.cvss2
         %label.control-label{ :for => "e" } Exploitability
         .controls
-          %select{ :name => "e", :id => "e" }
+          %select#e{ :name => "e", "data-cvss-tag" => "E" }
             %option Not Defined
             %option Unproven Exploit Exists
             %option Proof-of-Concept Code
             %option Functional Exploit Exists
             %option High
-      .control-group
+      .control-group.cvss2
         %label.control-label{ :for => "rl" } Remediation Level
         .controls
-          %select{ :name => "rl", :id => "rl" }
+          %select#rl{ :name => "rl", "data-cvss-tag" => "RL" }
             %option Not Defined
             %option Official Fix
             %option Temporary Fix
             %option Workaround
             %option Unavailable
-      .control-group
+      .control-group.cvss2
         %label.control-label{ :for => "rc" } Report Confidence
         .controls
-          %select{ :name => "rc", :id => "rc" }
+          %select#rc{ :name => "rc", "data-cvss-tag" => "RC" }
             %option Not Defined
             %option Unconfirmed
             %option Uncorroborated
             %option Confirmed
-      .control-group
+      .control-group.cvss2
         %label.control-label{ :for => "cdp" } Collateral Damage Potential
         .controls
-          %select{ :name => "cdp", :id => "cdp" }
+          %select#cdp{ :name => "cdp", "data-cvss-tag" => "CDP" }
             %option Not Defined
             %option None
             %option Low
             %option Low-Medium
             %option Medium-High
             %option High
-      .control-group
+      .control-group.cvss2
         %label.control-label{ :for => "td" } Target Distribution
         .controls
-          %select{ :name => "td", :id => "td" }
+          %select#td{ :name => "td", "data-cvss-tag" => "TD" }
             %option Not Defined
             %option None
             %option Low
             %option Medium
             %option High
-      .control-group
+      .control-group.cvss2
         %label.control-label{ :for => "cr" } Confidentiality Requirement
         .controls
-          %select{ :name => "cr", :id => "cr" }
+          %select#cr{ :name => "cr", "data-cvss-tag" => "CR" }
             %option Not Defined
             %option Low
             %option Medium
             %option High
-      .control-group
+      .control-group.cvss2
         %label.control-label{ :for => "ir" } Integrity Requirement
         .controls
-          %select{ :name => "ir", :id => "ir" }
+          %select#ir{ :name => "ir", "data-cvss-tag" => "IR" }
             %option Not Defined
             %option Low
             %option Medium
             %option High
-      .control-group
+      .control-group.cvss2
         %label.control-label{ :for => "ar" } Availability Requirement
         .controls
-          %select{ :name => "ar", :id => "ar" }
+          %select#ar{ :name => "ar", "data-cvss-tag" => "AR" }
             %option Not Defined
             %option Low
             %option Medium
             %option High
-      %script
-        document.getElementById('vs').addEventListener('input', function() {
-        var vector = this.value.trim().split("/");
-
-        for(var i in vector){
-        var part = vector[i];
-        //CVSS:2.0/AV:N/AC:L/AU:N/C:H/I:N/A:N
-
-        // AV
-        if(part.includes("AV:")){
-        if(part.includes(":L")){
-        document.getElementById('av').selectedIndex=0;
-        }
-        if(part.includes(":A")){
-        document.getElementById('av').selectedIndex=1;
-        }
-        if(part.includes(":N")){
-        document.getElementById('av').selectedIndex=2;
-        }
-        }
-
-        // AC
-        if(part.includes("AC:")){
-        if(part.includes(":H")){
-        document.getElementById('ac').selectedIndex=0;
-        }
-        if(part.includes(":M")){
-        document.getElementById('ac').selectedIndex=1;
-        }
-        if(part.includes(":L")){
-        document.getElementById('ac').selectedIndex=2;
-        }
-        }
-
-        // AU
-        if(part.includes("AU:")){
-        if(part.includes(":M")){
-        document.getElementById('au').selectedIndex=0;
-        }
-        if(part.includes(":S")){
-        document.getElementById('au').selectedIndex=1;
-        }
-        if(part.includes(":N")){
-        document.getElementById('au').selectedIndex=2;
-        }
-        }
-
-        // C
-        if(part.includes("C:")){
-        if(part.includes(":N")){
-        document.getElementById('c').selectedIndex=0;
-        }
-        if(part.includes(":P")){
-        document.getElementById('c').selectedIndex=1;
-        }
-        if(part.includes(":C")){
-        document.getElementById('c').selectedIndex=2;
-        }
-        }
-
-        // I
-        if(part.includes("I:")){
-        if(part.includes(":N")){
-        document.getElementById('i').selectedIndex=0;
-        }
-        if(part.includes(":P")){
-        document.getElementById('i').selectedIndex=1;
-        }
-        if(part.includes(":C")){
-        document.getElementById('i').selectedIndex=2;
-        }
-        }
-
-        // A
-        if(part.includes("A:")){
-        if(part.includes(":N")){
-        document.getElementById('a').selectedIndex=0;
-        }
-        if(part.includes(":P")){
-        document.getElementById('a').selectedIndex=1;
-        }
-        if(part.includes(":C")){
-        document.getElementById('a').selectedIndex=2;
-        }
-        }
-
-        // E
-        if(part.includes("E:")){
-        if(part.includes(":ND")){
-        document.getElementById('e').selectedIndex=0;
-        }
-        if(part.includes(":U")){
-        document.getElementById('e').selectedIndex=1;
-        }
-        if(part.includes(":POC")){
-        document.getElementById('e').selectedIndex=2;
-        }
-        if(part.includes(":F")){
-        document.getElementById('e').selectedIndex=3;
-        }
-        if(part.includes(":H")){
-        document.getElementById('e').selectedIndex=4;
-        }
-        }
-
-        // RL
-        if(part.includes("RL:")){
-        if(part.includes(":ND")){
-        document.getElementById('rl').selectedIndex=0;
-        }
-        if(part.includes(":OF")){
-        document.getElementById('rl').selectedIndex=1;
-        }
-        if(part.includes(":TF")){
-        document.getElementById('rl').selectedIndex=2;
-        }
-        if(part.includes(":W")){
-        document.getElementById('rl').selectedIndex=3;
-        }
-        if(part.includes(":U")){
-        document.getElementById('rl').selectedIndex=4;
-        }
-        }
-
-        // RC
-        if(part.includes("RC:")){
-        if(part.includes(":ND")){
-        document.getElementById('rc').selectedIndex=0;
-        }
-        if(part.includes(":UC")){
-        document.getElementById('rc').selectedIndex=1;
-        }
-        if(part.includes(":UR")){
-        document.getElementById('rc').selectedIndex=2;
-        }
-        if(part.includes(":C")){
-        document.getElementById('rc').selectedIndex=3;
-        }
-        }
-
-        // CDP
-        if(part.includes("CDP:")){
-        if(part.includes(":ND")){
-        document.getElementById('cdp').selectedIndex=0;
-        }
-        if(part.includes(":N")){
-        document.getElementById('cdp').selectedIndex=1;
-        }
-        if(part.includes(":LM")){
-        document.getElementById('cdp').selectedIndex=2;
-        }
-        if(part.includes(":MH")){
-        document.getElementById('cdp').selectedIndex=3;
-        }
-        if(part.includes(":H")){
-        document.getElementById('cdp').selectedIndex=4;
-        }
-        }
-
-        // TD
-        if(part.includes("TD:")){
-        if(part.includes(":ND")){
-        document.getElementById('td').selectedIndex=0;
-        }
-        if(part.includes(":N")){
-        document.getElementById('td').selectedIndex=1;
-        }
-        if(part.includes(":L")){
-        document.getElementById('td').selectedIndex=2;
-        }
-        if(part.includes(":M")){
-        document.getElementById('td').selectedIndex=3;
-        }
-        if(part.includes(":H")){
-        document.getElementById('td').selectedIndex=4;
-        }
-        }
-
-        // CD
-        if(part.includes("CR:")){
-        if(part.includes(":ND")){
-        document.getElementById('cd').selectedIndex=0;
-        }
-        if(part.includes(":L")){
-        document.getElementById('cd').selectedIndex=1;
-        }
-        if(part.includes(":M")){
-        document.getElementById('cd').selectedIndex=2;
-        }
-        if(part.includes(":H")){
-        document.getElementById('cd').selectedIndex=3;
-        }
-        }
-
-        // IR
-        if(part.includes("IR:")){
-        if(part.includes(":ND")){
-        document.getElementById('ir').selectedIndex=0;
-        }
-        if(part.includes(":L")){
-        document.getElementById('ir').selectedIndex=1;
-        }
-        if(part.includes(":M")){
-        document.getElementById('ir').selectedIndex=2;
-        }
-        if(part.includes(":H")){
-        document.getElementById('ir').selectedIndex=3;
-        }
-        }
-
-        // AR
-        if(part.includes("AR:")){
-        if(part.includes(":ND")){
-        document.getElementById('ar').selectedIndex=0;
-        }
-        if(part.includes(":L")){
-        document.getElementById('ar').selectedIndex=1;
-        }
-        if(part.includes(":M")){
-        document.getElementById('ar').selectedIndex=2;
-        }
-        if(part.includes(":H")){
-        document.getElementById('ar').selectedIndex=3;
-        }
-        }
-
-        }
-        });
       .control-group
         %label.control-label{ :for => "effort" } Remediation Effort
         .controls
@@ -671,8 +227,8 @@
           %a.btn.btn-info{ :href=> "#mymodal", "data-toggle" => "modal" }
             CVSS Vector String
         .controls
-          %input.form-control#vs{ :type => "text", :placeholder=>"CVSS Vector String", :style=>"width:35em" }
-        .modal.modal.hide.fade#mymodal{ :tabindex => "-1", :role => "dialog", "aria-labelledby" => "modal-label", "aria-hidden" => "true"}
+          %input.form-control#vs{ :type => "text", :placeholder=> "CVSS Vector String", :style=> "width:35em" }
+        .modal.modal.hide.fade#mymodal{ :tabindex => "-1", :role => "dialog", "aria-labelledby" => "modal-label", "aria-hidden" => "true" }
           .modal-header
             %button.close{ :type => "button", "data-dismiss" => "modal", "aria-hidden" => "true" }
               x
@@ -680,8 +236,8 @@
               CVSS Vector String
           .modal-body
             %link{ :rel => "stylesheet", :type => "text/css", :media => "all", :href => "/css/cvss.css" }
-            %script{:src => "/js/cvsscalc30.js"}
-            %script{ :src => "/js/cvss3.js"}
+            %script{ :src => "/js/cvsscalc30.js" }
+            %script{ :src => "/js/cvss3.js" }
             %div#cvssboard
       %span.input-group-btn
       .control-group.cvss3
@@ -843,11 +399,11 @@
         %label.control-label{ :for => "risk" } Vulnerability Risk Level
         .controls
           %select{ :name => "risk" }
-            %option{:value => 0}= "None"
-            %option{:value => 1}= "Low"
-            %option{:value => 2}= "Moderate"
-            %option{:value => 3}= "High"
-            %option{:value => 4}= "Critical"
+            %option{ :value => 0 }= "None"
+            %option{ :value => 1 }= "Low"
+            %option{ :value => 2 }= "Moderate"
+            %option{ :value => 3 }= "High"
+            %option{ :value => 4 }= "Critical"
       .control-group
         %label.control-label{ :for => "severity" } Severity
         .controls
@@ -857,7 +413,7 @@
       .control-group
         %label.control-label{ :for => "severity_rationale" } Severity Rationale
         .controls
-          %textarea{ :rows => '3', :class => 'input-xxlarge allowMarkupShortcut', :id => 'severity_rationale', :name => 'severity_rationale'}
+          %textarea.input-xxlarge.allowMarkupShortcut#severity_rationale{ :rows => "3", :name => "severity_rationale" }
       .control-group
         %label.control-label{ :for => "likelihood" } Likelihood
         .controls
@@ -867,7 +423,7 @@
       .control-group
         %label.control-label{ :for => "likelihood_rationale" } Likelihood Rationale
         .controls
-          %textarea{ :rows => '3', :class => 'input-xxlarge allowMarkupShortcut', :id => 'likelihood_rationale', :name => 'likelihood_rationale'}
+          %textarea.input-xxlarge.allowMarkupShortcut#likelihood_rationale{ :rows => "3", :name => "likelihood_rationale" }
 
     - else
       .control-group
@@ -887,25 +443,25 @@
         %label.control-label{ :for => "risk" } Vulnerability Risk Level
         .controls
           %select{ :name => "risk" }
-            %option{:value => 0}= "Informational"
-            %option{:value => 1}= "Low"
-            %option{:value => 2}= "Moderate"
-            %option{:value => 3}= "High"
-            %option{:value => 4}= "Critical"
+            %option{ :value => 0 }= "Informational"
+            %option{ :value => 1 }= "Low"
+            %option{ :value => 2 }= "Moderate"
+            %option{ :value => 3 }= "High"
+            %option{ :value => 4 }= "Critical"
     .control-group
       %label.control-label{ :for => "overview" }
-        %a{:href=> '#modaloverview', "data-toggle"=>'modal', :class=>'btn btn-info'}
+        %a.btn.btn-info{ :href=> "#modaloverview", "data-toggle" => "modal" }
           Overview
-      .modal{:id=>'modaloverview', :class=>'modal hide fade', :tabindex=>'-1', :role=>'dialog', "aria-labelledby"=>'modal-label', "aria-hidden"=>'true'}
+      .modal.modal.hide.fade#modaloverview{ :tabindex=> "-1", :role=> "dialog", "aria-labelledby" => "modal-label", "aria-hidden" => "true" }
         .modal-header
-          %button{:type=>'button', :class=>'close', "data-dismiss"=>"modal", "aria-hidden"=>"true"}
+          %button.close{ :type=> "button", "data-dismiss" => "modal", "aria-hidden" => "true" }
             x
-          %h3{:id=>"modal-label"}
+          %h3#modal-label
             Meta Markup
         .modal-body
           %p
             There are four markup sets you can use in the Overview and the Remediation summary. This text is converted inside of Microsoft Word.
-            %p{:class=>"text-error"}
+            %p.text-error
               YOU MUST CLOSE ALL TAGS. OTHERWISE YOU CAN DESTROY ALL TEXT FORMATTING. SEE EXAMPLES BELOW.
             %b
               Review the finding "TEST - Markup Tester" for a clear example. As always, press preview to see the finding in Word.
@@ -951,15 +507,15 @@
               [[[ code, code goes here ]]]
 
       .controls
-        %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :id => 'overview', :name => 'overview'}
+        %textarea.input-xxlarge.allowMarkupShortcut#overview{ :rows => "10", :name => "overview" }
     .control-group
       %label.control-label{ :for => "pocu" } Proof of Concept
       .controls
-        %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :id => 'poc', :name => 'poc', :id => 'pocu'}
+        %textarea.input-xxlarge.allowMarkupShortcut#poc{ :rows => "10", :name => "poc" }
     - attachments=''
     - if @attaches
       - @attaches.each do |attach|
-        - attachments = attachments + "{name: '#{attach}'},"
+        - attachments = attachments + "{name: '#{attach}' },"
     / autosuggest code is care of bootstrap-suggest.js
     :javascript
       var files = [
@@ -982,441 +538,154 @@
       .control-group
         %label.control-label{ :for => "affected_hosts" } Affected Hosts
         .controls
-          %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :id => 'affected_hosts', :name => 'affected_hosts'}
+          %textarea.input-xxlarge.allowMarkupShortcut#affected_hosts{ :rows => "10", :name => "affected_hosts" }
     .control-group
       %label.control-label{ :for => "remediation" } Remediation
       .controls
-        %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :name => 'remediation'}
+        %textarea.input-xxlarge.allowMarkupShortcut{ :rows => "10", :name => "remediation" }
     .control-group
       %label.control-label{ :for => "references" } References (One Per Line)
       .controls
-        %textarea{ :rows => '5', :class => 'input-xxlarge allowMarkupShortcut', :name => 'references'}
+        %textarea.input-xxlarge.allowMarkupShortcut{ :rows => "5", :name => "references" }
     - if !@master
       .control-group
         %label.control-label{ :for => "notes" } Notes Data
-        %i{:class=>"icon-chevron-down", "data-toggle"=>"collapse", "data-target"=>"#info_2", :id=>"actionButton"}
-        .info{ :id => "info_2", :class => "collapse out" }
+        %i.icon-chevron-down#actionButton{ "data-toggle" => "collapse", "data-target" => "#info_2" }
+        .info.collapse.out#info_2
           %label
             Notes
           .controls
-          %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :name => 'notes'}
+          %textarea.input-xxlarge.allowMarkupShortcut{ :rows => "10", :name => "notes" }
             - if @finding
               - if @finding.notes
                 #{meta_markup(@finding.notes)}
     - if !@master
       .control-group
         %label.control-label{ :for => "preso" } Presentation Data
-        %i{:class=>"icon-chevron-down", "data-toggle"=>"collapse", "data-target"=>"#info_1", :id=>"actionButton"}
-        .info{ :id => "info_1", :class => "collapse out" }
+        %i.icon-chevron-down#actionButton{ "data-toggle" => "collapse", "data-target" => "#info_1" }
+        .info.collapse.out#info_1
           %label
             Presentation Points (One Per Line)
           .controls
-          %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :name => 'presentation_points'}
+          %textarea.input-xxlarge.allowMarkupShortcut{ :rows => "10", :name => "presentation_points" }
             - if @finding
               - if @finding.presentation_points
                 #{meta_markup(@finding.presentation_points)}
           %label
             Presentation Remediation Points (One Per Line)
           .controls
-          %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :name => 'presentation_rem_points'}
+          %textarea.input-xxlarge.allowMarkupShortcut{ :rows => "10", :name => "presentation_rem_points" }
             - if @finding
               - if @finding.presentation_rem_points
                 #{meta_markup(@finding.presentation_rem_points)}
 
     - id_r = @report ? "/report/#{@report.id}/findings" : "/master/findings"
-    %input{:type => 'submit', :value => 'Save'}
-    %a{ :href => "#{id_r}"}
-      %input{ :type => "button", :value => 'Cancel'}
+    %input{ :type => "submit", :value => "Save" }
+    %a{ :href => "#{id_r}" }
+      %input{ :type => "button", :value => "Cancel" }
 
-  -if @cvssv3
-    :css
-      .cvss3 .cvssjs .results {
-        padding: 0px;
-      }
+-if @cvss
+  :javascript
+    cvss_prefix = "CVSS:2.0";
 
-    :javascript
-      var cvssjs;
+-if @cvssv3
+  :javascript
+    cvss_prefix = "CVSS:3.0";
 
-      function updateCVSS() {
-        updateCVSSSummary(true);
-      }
+-if @cvss or @cvssv3
+  :css
+    .cvss3 .cvssjs .results,
+    .cvss2 .cvssjs .results {
+      padding: 0px;
+    }
 
-      function updateCVSSSummary(updateCVSSJS) {
-        var vectorString = "CVSS:3.0";
+  :javascript
+    var cvssjs;
+    var cvss_prefix;
 
-        $("select[data-cvss-tag]").each(function (index, element) {
-          if (element.value.toLowerCase() == "not defined") {
-            vectorString += "/" + element.getAttribute("data-cvss-tag") + ":X";
-          } else {
-            vectorString += "/" + element.getAttribute("data-cvss-tag") + ":" + element.value[0];
+    function updateCVSS() {
+      updateCVSSSummary(true);
+    }
+
+    function updateCVSSSummary(updateCVSSJS) {
+      var vectorString = cvss_prefix;
+
+      $("select[data-cvss-tag]").each(function (index, element) {
+        if (element.value.toLowerCase() == "not defined") {
+          vectorString += "/" + element.getAttribute("data-cvss-tag") + ":X";
+        } else {
+          var value;
+
+          if (element.value.toUpperCase() == "LOW-MEDIUM") {
+            value = "LM";
+          } else if (element.value.toUpperCase() == "MEDIUM-HIGH") {
+            value = "MH";
+          } else  {
+            value = element.value[0];
           }
-        });
-        var output = CVSS.calculateCVSSFromVector(vectorString);
 
-        $("#baseScore .results .score").text(output.baseMetricScore);
-        $("#baseScore .results .severity").text(output.baseSeverity);
-        $("#baseScore .results .severity").attr("class", "severity " + output.baseSeverity);
-        $("#temporalScore .results .score").text(output.temporalMetricScore);
-        $("#temporalScore .results .severity").text(output.temporalSeverity);
-        $("#temporalScore .results .severity").attr("class", "severity " + output.temporalSeverity);
-        $("#environmentalScore .results .score").text(output.environmentalMetricScore);
-        $("#environmentalScore .results .severity").text(output.environmentalSeverity);
-        $("#environmentalScore .results .severity").attr("class", "severity " + output.environmentalSeverity);
-
-        if (updateCVSSJS) {
-          cvssjs.set(vectorString);
+          vectorString += "/" + element.getAttribute("data-cvss-tag") + ":" + value;
         }
-      }
-
-      function updateDropdown(score){
-        var vector = score.trim().split("/");
-
-        for(var i in vector){
-          var part = vector[i];
-
-          if (part.length > 0){
-            part = part.toUpperCase();
-          }
-
-          //CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N/RL:O/CR:L
-          // AV
-          // LANP
-          if(part.includes("AV:") && !part.includes("MAV:")){
-            if(part.includes(":L")){
-              document.getElementById('attack_vector').selectedIndex=0;
-            }
-            if(part.includes(":A")){
-              document.getElementById('attack_vector').selectedIndex=1;
-            }
-            if(part.includes(":N")){
-              document.getElementById('attack_vector').selectedIndex=2;
-            }
-            if(part.includes(":P")){
-              document.getElementById('attack_vector').selectedIndex=3;
-            }
-          }
-
-          // AC
-          if(part.includes("AC:")  && !part.includes("MAC:")){
-            if(part.includes(":L")){
-              document.getElementById('attack_complexity').selectedIndex=0;
-            }
-            if(part.includes(":H")){
-              document.getElementById('attack_complexity').selectedIndex=1;
-            }
-          }
-
-          // PR NLH
-          if(part.includes("PR:")  && !part.includes("MPR:")){
-            if(part.includes(":N")){
-              document.getElementById('privileges_required').selectedIndex=0;
-            }
-            if(part.includes(":L")){
-              document.getElementById('privileges_required').selectedIndex=1;
-            }
-            if(part.includes(":H")){
-              document.getElementById('privileges_required').selectedIndex=2;
-            }
-          }
-
-          // UI
-          if(part.includes("UI:")){
-            if(part.includes(":N")){
-              document.getElementById('user_interaction').selectedIndex=0;
-            }
-            if(part.includes(":R")){
-              document.getElementById('user_interaction').selectedIndex=1;
-            }
-          }
-
-          // S
-          if(part.includes("S:")  && !part.includes("MS:")){
-            if(part.includes(":U")){
-              document.getElementById('scope').selectedIndex=0;
-            }
-            if(part.includes(":C")){
-              document.getElementById('scope').selectedIndex=1;
-            }
-          }
-
-          // I
-          if(part.includes("I:")  && !part.includes("MI:")){
-            if(part.includes(":N")){
-              document.getElementById('integrity').selectedIndex=0;
-            }
-            if(part.includes(":L")){
-              document.getElementById('integrity').selectedIndex=1;
-            }
-            if(part.includes(":H")){
-              document.getElementById('integrity').selectedIndex=2;
-            }
-          }
-
-          // C
-          if(part.includes("C:") && !part.includes("MC:") && !part.includes("MAC:")){
-            if(part.includes(":N")){
-              document.getElementById('confidentiality-impact').selectedIndex=0;
-            }
-            if(part.includes(":L")){
-              document.getElementById('confidentiality-impact').selectedIndex=1;
-            }
-            if(part.includes(":H")){
-              document.getElementById('confidentiality-impact').selectedIndex=2;
-            }
-          }
-
-          // A
-          if(part.includes("A:")  && !part.includes("MA:")){
-            if(part.includes(":N")){
-              document.getElementById('availability').selectedIndex=0;
-            }
-            if(part.includes(":L")){
-              document.getElementById('availability').selectedIndex=1;
-            }
-            if(part.includes(":H")){
-              document.getElementById('availability').selectedIndex=2;
-            }
-          }
-
-          // Exploit Code Maturity
-          if(part.includes("E:")){
-            if(part.includes(":X")){
-              document.getElementById('exploit_maturity').selectedIndex=0;
-            }
-            if(part.includes(":U")){
-              document.getElementById('exploit_maturity').selectedIndex=1;
-            }
-            if(part.includes(":P")){
-              document.getElementById('exploit_maturity').selectedIndex=2;
-            }
-            if(part.includes(":F")){
-              document.getElementById('exploit_maturity').selectedIndex=3;
-            }
-          }
-
-
-          // Remediation Level
-          if(part.includes("RL:")){
-            if(part.includes(":X")){
-              document.getElementById('remeditation_level').selectedIndex=0;
-            }
-            if(part.includes(":O")){
-              document.getElementById('remeditation_level').selectedIndex=1;
-            }
-            if(part.includes(":T")){
-              document.getElementById('remeditation_level').selectedIndex=2;
-            }
-            if(part.includes(":W")){
-              document.getElementById('remeditation_level').selectedIndex=3;
-            }
-            if(part.includes(":U")){
-              document.getElementById('remeditation_level').selectedIndex=4;
-            }
-          }
-
-
-          // report confidence
-          if(part.includes("RC:")){
-            if(part.includes(":X")){
-              document.getElementById('report_confidence').selectedIndex=0;
-            }
-            if(part.includes(":U")){
-              document.getElementById('report_confidence').selectedIndex=1;
-            }
-            if(part.includes(":R")){
-              document.getElementById('report_confidence').selectedIndex=2;
-            }
-            if(part.includes(":C")){
-              document.getElementById('report_confidence').selectedIndex=3;
-            }
-          }
-
-          // confidentiality-requirement
-          if(part.includes("CR:")){
-            if(part.includes(":X")){
-              document.getElementById('confidentiality_requirement').selectedIndex=0;
-            }
-            if(part.includes(":L")){
-              document.getElementById('confidentiality_requirement').selectedIndex=1;
-            }
-            if(part.includes(":M")){
-              document.getElementById('confidentiality_requirement').selectedIndex=2;
-            }
-            if(part.includes(":H")){
-              document.getElementById('confidentiality_requirement').selectedIndex=3;
-            }
-          }
-
-          // integrity-requirement
-          if(part.includes("IR:")){
-            if(part.includes(":X")){
-              document.getElementById('integrity_requirement').selectedIndex=0;
-            }
-            if(part.includes(":L")){
-              document.getElementById('integrity_requirement').selectedIndex=1;
-            }
-            if(part.includes(":M")){
-              document.getElementById('integrity_requirement').selectedIndex=2;
-            }
-            if(part.includes(":H")){
-              document.getElementById('integrity_requirement').selectedIndex=3;
-            }
-          }
-
-          // integrity-requirement
-          if(part.includes("AR:")){
-            if(part.includes(":X")){
-              document.getElementById('availability_requirement').selectedIndex=0;
-            }
-            if(part.includes(":L")){
-              document.getElementById('availability_requirement').selectedIndex=1;
-            }
-            if(part.includes(":M")){
-              document.getElementById('availability_requirement').selectedIndex=2;
-            }
-            if(part.includes(":H")){
-              document.getElementById('availability_requirement').selectedIndex=3;
-            }
-          }
-
-          // modified-attack-vector
-          if(part.includes("MAV:")){
-            if(part.includes(":X")){
-              document.getElementById('mod_attack_vector').selectedIndex=0;
-            }
-            if(part.includes(":L")){
-              document.getElementById('mod_attack_vector').selectedIndex=1;
-            }
-            if(part.includes(":A")){
-              document.getElementById('mod_attack_vector').selectedIndex=2;
-            }
-            if(part.includes(":N")){
-              document.getElementById('mod_attack_vector').selectedIndex=3;
-            }
-            if(part.includes(":P")){
-              document.getElementById('mod_attack_vector').selectedIndex=4;
-            }
-          }
-
-          // modified-attack-vector
-          if(part.includes("MAC:")){
-            if(part.includes(":X")){
-              document.getElementById('mod_attack_complexity').selectedIndex=0;
-            }
-            if(part.includes(":L")){
-              document.getElementById('mod_attack_complexity').selectedIndex=1;
-            }
-            if(part.includes(":H")){
-              document.getElementById('mod_attack_complexity').selectedIndex=2;
-            }
-          }
-
-          // modified-privileges-Required
-          if(part.includes("MPR:")){
-            if(part.includes(":X")){
-              document.getElementById('mod_privileges_required').selectedIndex=0;
-            }
-            if(part.includes(":N")){
-              document.getElementById('mod_privileges_required').selectedIndex=1;
-            }
-            if(part.includes(":L")){
-              document.getElementById('mod_privileges_required').selectedIndex=2;
-            }
-            if(part.includes(":H")){
-              document.getElementById('mod_privileges_required').selectedIndex=3;
-            }
-          }
-
-          // modified-user-interaction
-          if(part.includes("MUI:")){
-            if(part.includes(":X")){
-              document.getElementById('mod_user_interaction').selectedIndex=0;
-            }
-            if(part.includes(":N")){
-              document.getElementById('mod_user_interaction').selectedIndex=1;
-            }
-            if(part.includes(":R")){
-              document.getElementById('mod_user_interaction').selectedIndex=2;
-            }
-          }
-
-          // modified-scope
-          if(part.includes("MS:")){
-            if(part.includes(":X")){
-              document.getElementById('mod_scope').selectedIndex=0;
-            }
-            if(part.includes(":U")){
-              document.getElementById('mod_scope').selectedIndex=1;
-            }
-            if(part.includes(":C")){
-              document.getElementById('mod_scope').selectedIndex=2;
-            }
-          }
-
-          // modified-confidentiality
-          if(part.includes("MC:")){
-            if(part.includes(":X")){
-              document.getElementById('mod_confidentiality').selectedIndex=0;
-            }
-            if(part.includes(":N")){
-              document.getElementById('mod_confidentiality').selectedIndex=1;
-            }
-            if(part.includes(":L")){
-              document.getElementById('mod_confidentiality').selectedIndex=2;
-            }
-            if(part.includes(":H")){
-              document.getElementById('mod_confidentiality').selectedIndex=3;
-            }
-          }
-
-          // modified-integrity
-          if(part.includes("MI:")){
-            if(part.includes(":X")){
-              document.getElementById('mod_integrity').selectedIndex=0;
-            }
-            if(part.includes(":N")){
-              document.getElementById('mod_integrity').selectedIndex=1;
-            }
-            if(part.includes(":L")){
-              document.getElementById('mod_integrity').selectedIndex=2;
-            }
-            if(part.includes(":H")){
-              document.getElementById('mod_integrity').selectedIndex=3;
-            }
-          }
-
-          // modified-availability
-          if(part.includes("MA:")){
-            if(part.includes(":X")){
-              document.getElementById('mod_availability').selectedIndex=0;
-            }
-            if(part.includes(":N")){
-              document.getElementById('mod_availability').selectedIndex=1;
-            }
-            if(part.includes(":L")){
-              document.getElementById('mod_availability').selectedIndex=2;
-            }
-            if(part.includes(":H")){
-              document.getElementById('mod_availability').selectedIndex=3;
-            }
-          }
-        }
-      }
-
-      $(document).ready(function() {
-        cvssjs = new CVSS.js("cvssboard", {
-          onchange: function() {
-            document.getElementById('vs').value = cvssjs.get().vector;
-            updateDropdown(cvssjs.get().vector);
-            updateCVSSSummary(false);
-          }
-        });
-
-        $(".cvss3 select").on("change", updateCVSS);
-        updateCVSSSummary(true);
-
-        $("#vs").on('change keydown paste input', function(){
-          updateDropdown(this.value);
-          updateCVSSSummary(true, false);
-        });
       });
+      var output = CVSS.calculateCVSSFromVector(vectorString);
+
+      $("#baseScore .results .score").text(output.baseMetricScore);
+      $("#baseScore .results .severity").text(output.baseSeverity);
+      $("#baseScore .results .severity").attr("class", "severity " + output.baseSeverity);
+      $("#temporalScore .results .score").text(output.temporalMetricScore);
+      $("#temporalScore .results .severity").text(output.temporalSeverity);
+      $("#temporalScore .results .severity").attr("class", "severity " + output.temporalSeverity);
+      $("#environmentalScore .results .score").text(output.environmentalMetricScore);
+      $("#environmentalScore .results .severity").text(output.environmentalSeverity);
+      $("#environmentalScore .results .severity").attr("class", "severity " + output.environmentalSeverity);
+
+      if (updateCVSSJS) {
+        cvssjs.set(vectorString);
+      }
+    }
+
+    function updateDropdown(score) {
+      var vector = score.trim().split("/");
+
+      for (var index = 1; index < vector.length; index++) {
+        var parts = vector[index].split(":");
+        var metric = parts[0].toUpperCase();
+        var metric_value = parts[1].toUpperCase();
+
+        if (metric_value == "_" || metric_value == "X") {
+          // Set the value to None
+          metric_value = "N";
+        }
+
+        selectCVSSByVal(document.querySelector("[data-cvss-tag='" + metric + "']"), metric_value);
+      }
+    }
+
+    function selectCVSSByVal(select, value) {
+      for (var index = 0; index < select.options.length; index++) {
+        var option = select.options[index];
+
+        if (option.value[0].toUpperCase() == value.toUpperCase()) {
+          select.value = option.value;
+          return;
+        }
+      }
+    }
+
+    $(document).ready(function() {
+      cvssjs = new CVSS.js("cvssboard", {
+        onchange: function() {
+          document.getElementById('vs').value = cvssjs.get().vector;
+          updateDropdown(cvssjs.get().vector);
+          updateCVSSSummary(false);
+        }
+      });
+
+      $(".cvss3 select, .cvss2 select").on("change", updateCVSS);
+      updateCVSSSummary(true);
+
+      $("#vs").on('change keydown paste input', function(){
+        updateDropdown(this.value);
+        updateCVSSSummary(true, false);
+      });
+    });

--- a/views/create_finding.haml
+++ b/views/create_finding.haml
@@ -8,55 +8,55 @@
   %br
   %form{ :class => "form-horizontal", :method => 'post', :enctype => 'application/x-www-form-urlencoded'}
     .control-group
-      %label{ :class => "control-label", :for => "title" } Title
+      %label.control-label{ :for => "title" } Title
       .controls
         %input{ :type => 'text', :name => 'title', :value => ""}
     - if !@master
       .control-group
-        %label{ :class => "control-label", :for => "assessment_type" } Assessment Type
+        %label.control-label{ :for => "assessment_type" } Assessment Type
         .controls
           %select{ :name => "assessment_type" }
             - options.assessment_types.each do |type|
               %option #{type}
     .control-group
-      %label{ :class => "control-label", :for => "type" } Finding Type
+      %label.control-label{ :for => "type" } Finding Type
       .controls
         %select{ :name => "type" }
           - options.finding_types.each do |type|
             %option #{type}
     - if @nessusmap
       .control-group
-        %label{ :class => "control-label", :for => "pluginid" } Add new nessus ID mapping
+        %label.control-label{ :for => "pluginid" } Add new nessus ID mapping
         .controls
           %input{ :type => 'text', :name => 'pluginid'}
     - if @vulnmap
       .control-group
-        %label{ :class => "control-label", :for => "msf_ref" } Add new Vuln ID mapping
+        %label.control-label{ :for => "msf_ref" } Add new Vuln ID mapping
         .controls
           %input{ :type => 'text', :name => 'msf_ref'}
     - if @dread
       .control-group
-        %label{ :class => "control-label", :for => "damage" } Damage
+        %label.control-label{ :for => "damage" } Damage
         .controls
           %input{ :type => 'number', :min => '0', :max => '10', :name => 'damage', :value => "0", :required => true}
       .control-group
-        %label{ :class => "control-label", :for => "reproducability" } Reproducibility
+        %label.control-label{ :for => "reproducability" } Reproducibility
         .controls
           %input{ :type => 'number', :min => '0', :max => '10', :name => 'reproducability', :value => "0", :required => true}
       .control-group
-        %label{ :class => "control-label", :for => "exploitability" } Exploitability
+        %label.control-label{ :for => "exploitability" } Exploitability
         .controls
           %input{ :type => 'number', :min => '0', :max => '10', :name => 'exploitability', :value => "0", :required => true}
       .control-group
-        %label{ :class => "control-label", :for => "affected_users" } Affected Users
+        %label.control-label{ :for => "affected_users" } Affected Users
         .controls
           %input{ :type => 'number', :min => '0', :max => '10', :name => 'affected_users', :value => "0", :required => true}
       .control-group
-        %label{ :class => "control-label", :for => "discoverability" } Discoverability
+        %label.control-label{ :for => "discoverability" } Discoverability
         .controls
           %input{ :type => 'number', :min => '0', :max => '10', :name => 'discoverability', :value => "0", :required => true}
       .control-group
-        %label{ :class => "control-label", :for => "effort" } Remediation Effort
+        %label.control-label{ :for => "effort" } Remediation Effort
         .controls
           %select{ :name => "effort" }
             %option LOW
@@ -64,7 +64,7 @@
             %option HARD
     - elsif @cvss
       .control-group
-        %label{ :class => "control-label", :for => "attack_vector" }
+        %label.control-label{ :for => "attack_vector" }
           %a{:href=> '#mymodal', "data-toggle"=>'modal', :class=>'btn btn-info'}
             CVSS Vector String
         .modal{:id=>'mymodal', :class=>'modal hide fade', :tabindex=>'-1', :role=>'dialog', "aria-labelledby"=>'modal-label', "aria-hidden"=>'true'}
@@ -320,49 +320,49 @@
         .controls
           %input{:type => "text", :class=>"form-control", :placeholder=>"CVSS Vector String", :id=>"vs", :style=>"width:35em"}
       .control-group
-        %label{ :class => "control-label", :for => "av" } Access Vector
+        %label.control-label{ :for => "av" } Access Vector
         .controls
           %select{ :name => "av", :id => "av" }
             %option Local
             %option Local Network
             %option Network
       .control-group
-        %label{ :class => "control-label", :for => "ac" } Access Complexity
+        %label.control-label{ :for => "ac" } Access Complexity
         .controls
           %select{ :name => "ac", :id => "ac" }
             %option High
             %option Medium
             %option Low
       .control-group
-        %label{ :class => "control-label", :for => "au" } Authentication
+        %label.control-label{ :for => "au" } Authentication
         .controls
           %select{ :name => "au", :id => "au" }
             %option Multiple
             %option Single
             %option None
       .control-group
-        %label{ :class => "control-label", :for => "c" } Confidentiality Impact
+        %label.control-label{ :for => "c" } Confidentiality Impact
         .controls
           %select{ :name => "c", :id => "c" }
             %option None
             %option Partial
             %option Complete
       .control-group
-        %label{ :class => "control-label", :for => "i" } Integrity Impact
+        %label.control-label{ :for => "i" } Integrity Impact
         .controls
           %select{ :name => "i", :id => "i" }
             %option None
             %option Partial
             %option Complete
       .control-group
-        %label{ :class => "control-label", :for => "a" } Availability Impact
+        %label.control-label{ :for => "a" } Availability Impact
         .controls
           %select{ :name => "a", :id => "a" }
             %option None
             %option Partial
             %option Complete
       .control-group
-        %label{ :class => "control-label", :for => "e" } Exploitability
+        %label.control-label{ :for => "e" } Exploitability
         .controls
           %select{ :name => "e", :id => "e" }
             %option Not Defined
@@ -371,7 +371,7 @@
             %option Functional Exploit Exists
             %option High
       .control-group
-        %label{ :class => "control-label", :for => "rl" } Remediation Level
+        %label.control-label{ :for => "rl" } Remediation Level
         .controls
           %select{ :name => "rl", :id => "rl" }
             %option Not Defined
@@ -380,7 +380,7 @@
             %option Workaround
             %option Unavailable
       .control-group
-        %label{ :class => "control-label", :for => "rc" } Report Confidence
+        %label.control-label{ :for => "rc" } Report Confidence
         .controls
           %select{ :name => "rc", :id => "rc" }
             %option Not Defined
@@ -388,7 +388,7 @@
             %option Uncorroborated
             %option Confirmed
       .control-group
-        %label{ :class => "control-label", :for => "cdp" } Collateral Damage Potential
+        %label.control-label{ :for => "cdp" } Collateral Damage Potential
         .controls
           %select{ :name => "cdp", :id => "cdp" }
             %option Not Defined
@@ -398,7 +398,7 @@
             %option Medium-High
             %option High
       .control-group
-        %label{ :class => "control-label", :for => "td" } Target Distribution
+        %label.control-label{ :for => "td" } Target Distribution
         .controls
           %select{ :name => "td", :id => "td" }
             %option Not Defined
@@ -407,7 +407,7 @@
             %option Medium
             %option High
       .control-group
-        %label{ :class => "control-label", :for => "cr" } Confidentiality Requirement
+        %label.control-label{ :for => "cr" } Confidentiality Requirement
         .controls
           %select{ :name => "cr", :id => "cr" }
             %option Not Defined
@@ -415,7 +415,7 @@
             %option Medium
             %option High
       .control-group
-        %label{ :class => "control-label", :for => "ir" } Integrity Requirement
+        %label.control-label{ :for => "ir" } Integrity Requirement
         .controls
           %select{ :name => "ir", :id => "ir" }
             %option Not Defined
@@ -423,7 +423,7 @@
             %option Medium
             %option High
       .control-group
-        %label{ :class => "control-label", :for => "ar" } Availability Requirement
+        %label.control-label{ :for => "ar" } Availability Requirement
         .controls
           %select{ :name => "ar", :id => "ar" }
             %option Not Defined
@@ -659,513 +659,188 @@
         }
         });
       .control-group
-        %label{ :class => "control-label", :for => "effort" } Remediation Effort
+        %label.control-label{ :for => "effort" } Remediation Effort
         .controls
           %select{ :name => "effort" }
             %option QUICK
             %option PLANNED
             %option INVOLVED
     - elsif @cvssv3
-      .control-group
-        %label{ :class => "control-label", :for => "attack_vector" }
-          %a{:href=> '#mymodal', "data-toggle"=>'modal', :class=>'btn btn-info'}
+      .control-group.cvss3
+        %label.control-label{ :for => "attack_vector" }
+          %a.btn.btn-info{ :href=> "#mymodal", "data-toggle" => "modal" }
             CVSS Vector String
         .controls
-          %input{:type => "text", :class=>"form-control", :placeholder=>"CVSS Vector String", :id=>"vs", :style=>"width:35em"}
-        .modal{:id=>'mymodal', :class=>'modal hide fade', :tabindex=>'-1', :role=>'dialog', "aria-labelledby"=>'modal-label', "aria-hidden"=>'true'}
+          %input.form-control#vs{ :type => "text", :placeholder=>"CVSS Vector String", :style=>"width:35em" }
+        .modal.modal.hide.fade#mymodal{ :tabindex => "-1", :role => "dialog", "aria-labelledby" => "modal-label", "aria-hidden" => "true"}
           .modal-header
-            %button{:type=>'button', :class=>'close', "data-dismiss"=>"modal", "aria-hidden"=>"true"}
+            %button.close{ :type => "button", "data-dismiss" => "modal", "aria-hidden" => "true" }
               x
-            %h3{:id=>"modal-label"}
+            %h3#modal-label
               CVSS Vector String
           .modal-body
-            %link{ :rel=>"stylesheet", :type=>"text/css", :media=>"all", :href=>"/css/cvss.css"}
+            %link{ :rel => "stylesheet", :type => "text/css", :media => "all", :href => "/css/cvss.css" }
+            %script{:src => "/js/cvsscalc30.js"}
             %script{ :src => "/js/cvss3.js"}
-            %div{ :id=>"cvssboard"}
-              %script
-                function updateDropdown(score){
-
-                var vector = score.trim().split("/");
-                for(var i in vector){
-                var part = vector[i];
-
-                if (part.length > 0){
-                part = part.toUpperCase();
-                }
-
-                //CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N/RL:O/CR:L
-                // AV
-                // LANP
-                if(part.includes("AV:") && !part.includes("MAV:")){
-                if(part.includes(":L")){
-                document.getElementById('attack_vector').selectedIndex=0;
-                }
-                if(part.includes(":A")){
-                document.getElementById('attack_vector').selectedIndex=1;
-                }
-                if(part.includes(":N")){
-                document.getElementById('attack_vector').selectedIndex=2;
-                }
-                if(part.includes(":P")){
-                document.getElementById('attack_vector').selectedIndex=3;
-                }
-                }
-
-                // AC
-                if(part.includes("AC:")  && !part.includes("MAC:")){
-                if(part.includes(":L")){
-                document.getElementById('attack_complexity').selectedIndex=0;
-                }
-                if(part.includes(":H")){
-                document.getElementById('attack_complexity').selectedIndex=1;
-                }
-                }
-
-                // PR NLH
-                if(part.includes("PR:")  && !part.includes("MPR:")){
-                if(part.includes(":N")){
-                document.getElementById('privileges_required').selectedIndex=0;
-                }
-                if(part.includes(":L")){
-                document.getElementById('privileges_required').selectedIndex=1;
-                }
-                if(part.includes(":H")){
-                document.getElementById('privileges_required').selectedIndex=2;
-                }
-                }
-
-                // UI
-                if(part.includes("UI:")){
-                if(part.includes(":N")){
-                document.getElementById('user_interaction').selectedIndex=0;
-                }
-                if(part.includes(":R")){
-                document.getElementById('user_interaction').selectedIndex=1;
-                }
-                }
-
-                // S
-                if(part.includes("S:")  && !part.includes("MS:")){
-                if(part.includes(":U")){
-                document.getElementById('scope').selectedIndex=0;
-                }
-                if(part.includes(":C")){
-                document.getElementById('scope').selectedIndex=1;
-                }
-                }
-
-                // I
-                if(part.includes("I:")  && !part.includes("MI:")){
-                if(part.includes(":N")){
-                document.getElementById('integrity').selectedIndex=0;
-                }
-                if(part.includes(":L")){
-                document.getElementById('integrity').selectedIndex=1;
-                }
-                if(part.includes(":H")){
-                document.getElementById('integrity').selectedIndex=2;
-                }
-                }
-
-                // C
-                if(part.includes("C:") && !part.includes("MC:") && !part.includes("MAC:")){
-                if(part.includes(":N")){
-                document.getElementById('confidentiality-impact').selectedIndex=0;
-                }
-                if(part.includes(":L")){
-                document.getElementById('confidentiality-impact').selectedIndex=1;
-                }
-                if(part.includes(":H")){
-                document.getElementById('confidentiality-impact').selectedIndex=2;
-                }
-                }
-
-                // A
-                if(part.includes("A:")  && !part.includes("MA:")){
-                if(part.includes(":N")){
-                document.getElementById('availability').selectedIndex=0;
-                }
-                if(part.includes(":L")){
-                document.getElementById('availability').selectedIndex=1;
-                }
-                if(part.includes(":H")){
-                document.getElementById('availability').selectedIndex=2;
-                }
-                }
-
-                // Exploit Code Maturity
-                if(part.includes("E:")){
-                if(part.includes(":X")){
-                document.getElementById('exploit_maturity').selectedIndex=0;
-                }
-                if(part.includes(":U")){
-                document.getElementById('exploit_maturity').selectedIndex=1;
-                }
-                if(part.includes(":P")){
-                document.getElementById('exploit_maturity').selectedIndex=2;
-                }
-                if(part.includes(":F")){
-                document.getElementById('exploit_maturity').selectedIndex=3;
-                }
-                }
-
-
-                // Remediation Level
-                if(part.includes("RL:")){
-                if(part.includes(":X")){
-                document.getElementById('remeditation_level').selectedIndex=0;
-                }
-                if(part.includes(":O")){
-                document.getElementById('remeditation_level').selectedIndex=1;
-                }
-                if(part.includes(":T")){
-                document.getElementById('remeditation_level').selectedIndex=2;
-                }
-                if(part.includes(":W")){
-                document.getElementById('remeditation_level').selectedIndex=3;
-                }
-                if(part.includes(":U")){
-                document.getElementById('remeditation_level').selectedIndex=4;
-                }
-                }
-
-
-                // report confidence
-                if(part.includes("RC:")){
-                if(part.includes(":X")){
-                document.getElementById('report_confidence').selectedIndex=0;
-                }
-                if(part.includes(":U")){
-                document.getElementById('report_confidence').selectedIndex=1;
-                }
-                if(part.includes(":R")){
-                document.getElementById('report_confidence').selectedIndex=2;
-                }
-                if(part.includes(":C")){
-                document.getElementById('report_confidence').selectedIndex=3;
-                }
-                }
-
-                // confidentiality-requirement
-                if(part.includes("CR:")){
-                if(part.includes(":X")){
-                document.getElementById('confidentiality_requirement').selectedIndex=0;
-                }
-                if(part.includes(":L")){
-                document.getElementById('confidentiality_requirement').selectedIndex=1;
-                }
-                if(part.includes(":M")){
-                document.getElementById('confidentiality_requirement').selectedIndex=2;
-                }
-                if(part.includes(":H")){
-                document.getElementById('confidentiality_requirement').selectedIndex=3;
-                }
-                }
-
-                // integrity-requirement
-                if(part.includes("IR:")){
-                if(part.includes(":X")){
-                document.getElementById('integrity_requirement').selectedIndex=0;
-                }
-                if(part.includes(":L")){
-                document.getElementById('integrity_requirement').selectedIndex=1;
-                }
-                if(part.includes(":M")){
-                document.getElementById('integrity_requirement').selectedIndex=2;
-                }
-                if(part.includes(":H")){
-                document.getElementById('integrity_requirement').selectedIndex=3;
-                }
-                }
-
-
-                // integrity-requirement
-                if(part.includes("AR:")){
-                if(part.includes(":X")){
-                document.getElementById('availability_requirement').selectedIndex=0;
-                }
-                if(part.includes(":L")){
-                document.getElementById('availability_requirement').selectedIndex=1;
-                }
-                if(part.includes(":M")){
-                document.getElementById('availability_requirement').selectedIndex=2;
-                }
-                if(part.includes(":H")){
-                document.getElementById('availability_requirement').selectedIndex=3;
-                }
-                }
-
-                // modified-attack-vector
-                if(part.includes("MAV:")){
-                if(part.includes(":X")){
-                document.getElementById('mod_attack_vector').selectedIndex=0;
-                }
-                if(part.includes(":L")){
-                document.getElementById('mod_attack_vector').selectedIndex=1;
-                }
-                if(part.includes(":A")){
-                document.getElementById('mod_attack_vector').selectedIndex=2;
-                }
-                if(part.includes(":N")){
-                document.getElementById('mod_attack_vector').selectedIndex=3;
-                }
-                if(part.includes(":P")){
-                document.getElementById('mod_attack_vector').selectedIndex=4;
-                }
-                }
-
-                // modified-attack-vector
-                if(part.includes("MAC:")){
-                if(part.includes(":X")){
-                document.getElementById('mod_attack_complexity').selectedIndex=0;
-                }
-                if(part.includes(":L")){
-                document.getElementById('mod_attack_complexity').selectedIndex=1;
-                }
-                if(part.includes(":H")){
-                document.getElementById('mod_attack_complexity').selectedIndex=2;
-                }
-                }
-
-                // modified-privileges-Required
-                if(part.includes("MPR:")){
-                if(part.includes(":X")){
-                document.getElementById('mod_privileges_required').selectedIndex=0;
-                }
-                if(part.includes(":N")){
-                document.getElementById('mod_privileges_required').selectedIndex=1;
-                }
-                if(part.includes(":L")){
-                document.getElementById('mod_privileges_required').selectedIndex=2;
-                }
-                if(part.includes(":H")){
-                document.getElementById('mod_privileges_required').selectedIndex=3;
-                }
-                }
-
-                // modified-user-interaction
-                if(part.includes("MUI:")){
-                if(part.includes(":X")){
-                document.getElementById('mod_user_interaction').selectedIndex=0;
-                }
-                if(part.includes(":N")){
-                document.getElementById('mod_user_interaction').selectedIndex=1;
-                }
-                if(part.includes(":R")){
-                document.getElementById('mod_user_interaction').selectedIndex=2;
-                }
-                }
-
-
-                // modified-scope
-                if(part.includes("MS:")){
-                if(part.includes(":X")){
-                document.getElementById('mod_scope').selectedIndex=0;
-                }
-                if(part.includes(":U")){
-                document.getElementById('mod_scope').selectedIndex=1;
-                }
-                if(part.includes(":C")){
-                document.getElementById('mod_scope').selectedIndex=2;
-                }
-                }
-
-                // modified-confidentiality
-                if(part.includes("MC:")){
-                if(part.includes(":X")){
-                document.getElementById('mod_confidentiality').selectedIndex=0;
-                }
-                if(part.includes(":N")){
-                document.getElementById('mod_confidentiality').selectedIndex=1;
-                }
-                if(part.includes(":L")){
-                document.getElementById('mod_confidentiality').selectedIndex=2;
-                }
-                if(part.includes(":H")){
-                document.getElementById('mod_confidentiality').selectedIndex=3;
-                }
-                }
-
-                // modified-integrity
-                if(part.includes("MI:")){
-                if(part.includes(":X")){
-                document.getElementById('mod_integrity').selectedIndex=0;
-                }
-                if(part.includes(":N")){
-                document.getElementById('mod_integrity').selectedIndex=1;
-                }
-                if(part.includes(":L")){
-                document.getElementById('mod_integrity').selectedIndex=2;
-                }
-                if(part.includes(":H")){
-                document.getElementById('mod_integrity').selectedIndex=3;
-                }
-                }
-
-
-                // modified-availability
-                if(part.includes("MA:")){
-                if(part.includes(":X")){
-                document.getElementById('mod_availability').selectedIndex=0;
-                }
-                if(part.includes(":N")){
-                document.getElementById('mod_availability').selectedIndex=1;
-                }
-                if(part.includes(":L")){
-                document.getElementById('mod_availability').selectedIndex=2;
-                }
-                if(part.includes(":H")){
-                document.getElementById('mod_availability').selectedIndex=3;
-                }
-                }
-                }}
-
-                var c = new CVSS.js("cvssboard", {
-                onchange: function() {
-                document.getElementById('vs').value = c.get().vector;
-                updateDropdown(c.get().vector);
-                }
-                });
-
-                $("#vs").on('change keydown paste input', function(){
-                updateDropdown(this.value);
-                });
-      %span{:class=>"input-group-btn"}
-      .control-group
-        %label{ :class => "control-label", :for => "attack_vector" } Attack Vector
+            %div#cvssboard
+      %span.input-group-btn
+      .control-group.cvss3
+        %label.control-label{ :for => "attack_vector" } Base Score
         .controls
-          %select{ :name => "attack_vector", :id => "attack_vector" }
+          #baseScore.cvssjs
+            .results
+              %span.score
+              %span.severity
+      .control-group.cvss3
+        %label.control-label{ :for => "attack_vector" } Temporal Score
+        .controls
+          #temporalScore.cvssjs
+            .results
+              %span.score
+              %span.severity
+      .control-group.cvss3
+        %label.control-label{ :for => "attack_vector" } Environmental Score
+        .controls
+          #environmentalScore.cvssjs
+            .results
+              %span.score
+              %span.severity
+
+      .control-group.cvss3
+        %label.control-label{ :for => "attack_vector" } Attack Vector
+        .controls
+          %select#attack_vector{ :name => "attack_vector", "data-cvss-tag" => "AV" }
             - options.attack_vector.each do |attack_vector|
               %option #{attack_vector}
-      .control-group
-        %label{ :class => "control-label", :for => "attack_complexity" } Attack Complexity
+      .control-group.cvss3
+        %label.control-label{ :for => "attack_complexity" } Attack Complexity
         .controls
-          %select{ :name => "attack_complexity", :id =>  "attack_complexity"}
+          %select#attack_complexity{ :name => "attack_complexity", "data-cvss-tag" => "AC" }
             - options.attack_complexity.each do |attack_complexity|
               %option #{attack_complexity}
-      .control-group
-        %label{ :class => "control-label", :for => "privileges_required" } Privileges Required
+      .control-group.cvss3
+        %label.control-label{ :for => "privileges_required" } Privileges Required
         .controls
-          %select{ :name => "privileges_required", :id =>  "privileges_required"}
+          %select#privileges_required{ :name => "privileges_required", "data-cvss-tag" => "PR" }
             - options.privileges_required.each do |privileges_required|
               %option #{privileges_required}
-      .control-group
-        %label{ :class => "control-label", :for => "user_interaction" } User Interaction
+      .control-group.cvss3
+        %label.control-label{ :for => "user_interaction" } User Interaction
         .controls
-          %select{ :name => "user_interaction", :id => "user_interaction" }
+          %select#user_interaction{ :name => "user_interaction", "data-cvss-tag" => "UI" }
             - options.user_interaction.each do |user_interaction|
               %option #{user_interaction}
-      .control-group
-        %label{ :class => "control-label", :for => "scope_cvss" } Scope
+      .control-group.cvss3
+        %label.control-label{ :for => "scope_cvss" } Scope
         .controls
-          %select{ :name => "scope_cvss", :id => "scope" }
+          %select#scope{ :name => "scope_cvss", "data-cvss-tag" => "S" }
             - options.scope_cvss.each do |scope_cvss|
               %option #{scope_cvss}
-      .control-group
-        %label{ :class => "control-label", :for => "confidentiality" } Confidentiality
+      .control-group.cvss3
+        %label.control-label{ :for => "confidentiality" } Confidentiality
         .controls
-          %select{ :name => "confidentiality", :id => "confidentiality-impact" }
+          %select#confidentiality-impact{ :name => "confidentiality", "data-cvss-tag" => "C" }
             - options.confidentiality.each do |confidentiality|
               %option #{confidentiality}
-      .control-group
-        %label{ :class => "control-label", :for => "integrity" } Integrity
+      .control-group.cvss3
+        %label.control-label{ :for => "integrity" } Integrity
         .controls
-          %select{ :name => "integrity", :id => "integrity" }
+          %select#integrity{ :name => "integrity", "data-cvss-tag" => "I" }
             - options.integrity.each do |integrity|
               %option #{integrity}
-      .control-group
-        %label{ :class => "control-label", :for => "availability" } Availability
+      .control-group.cvss3
+        %label.control-label{ :for => "availability" } Availability
         .controls
-          %select{ :name => "availability", :id => "availability" }
+          %select#availability{ :name => "availability", "data-cvss-tag" => "A" }
             - options.availability.each do |availability|
               %option #{availability}
-      .control-group
-        %label{ :class => "control-label", :for => "exploit_maturity" } Exploit Code Maturity
+      .control-group.cvss3
+        %label.control-label{ :for => "exploit_maturity" } Exploit Code Maturity
         .controls
-          %select{ :name => "exploit_maturity", :id => "exploit_maturity" }
+          %select#exploit_maturity{ :name => "exploit_maturity", "data-cvss-tag" => "E" }
             - options.exploit_maturity.each do |exploit_maturity|
               %option #{exploit_maturity}
-      .control-group
-        %label{ :class => "control-label", :for => "remeditation_level" } Remediation Level
+      .control-group.cvss3
+        %label.control-label{ :for => "remeditation_level" } Remediation Level
         .controls
-          %select{ :name => "remeditation_level", :id => "remeditation_level" }
+          %select#remeditation_level{ :name => "remeditation_level", "data-cvss-tag" => "RL" }
             - options.remeditation_level.each do |remeditation_level|
               %option #{remeditation_level}
-      .control-group
-        %label{ :class => "control-label", :for => "report_confidence" } Report Confidence
+      .control-group.cvss3
+        %label.control-label{ :for => "report_confidence" } Report Confidence
         .controls
-          %select{ :name => "report_confidence", :id => "report_confidence" }
+          %select#report_confidence{ :name => "report_confidence", "data-cvss-tag" => "RC" }
             - options.report_confidence.each do |report_confidence|
               %option #{report_confidence}
-      .control-group
-        %label{ :class => "control-label", :for => "confidentiality_requirement" } Confidentiality Requirement
+      .control-group.cvss3
+        %label.control-label{ :for => "confidentiality_requirement" } Confidentiality Requirement
         .controls
-          %select{ :name => "confidentiality_requirement", :id => "confidentiality_requirement" }
+          %select#confidentiality_requirement{ :name => "confidentiality_requirement", "data-cvss-tag" => "CR" }
             - options.confidentiality_requirement.each do |confidentiality_requirement|
               %option #{confidentiality_requirement}
-      .control-group
-        %label{ :class => "control-label", :for => "integrity_requirement" } Integrity Requirement
+      .control-group.cvss3
+        %label.control-label{ :for => "integrity_requirement" } Integrity Requirement
         .controls
-          %select{ :name => "integrity_requirement", :id => "integrity_requirement" }
+          %select#integrity_requirement{ :name => "integrity_requirement", "data-cvss-tag" => "IR" }
             - options.integrity_requirement.each do |integrity_requirement|
               %option #{integrity_requirement}
-      .control-group
-        %label{ :class => "control-label", :for => "availability_requirement" } Availability Requirement
+      .control-group.cvss3
+        %label.control-label{ :for => "availability_requirement" } Availability Requirement
         .controls
-          %select{ :name => "availability_requirement", :id => "availability_requirement" }
+          %select#availability_requirement{ :name => "availability_requirement", "data-cvss-tag" => "AR" }
             - options.availability_requirement.each do |availability_requirement|
               %option #{availability_requirement}
-      .control-group
-        %label{ :class => "control-label", :for => "mod_attack_vector" } Modified Attack Vector
+      .control-group.cvss3
+        %label.control-label{ :for => "mod_attack_vector" } Modified Attack Vector
         .controls
-          %select{ :name => "mod_attack_vector", :id => "mod_attack_vector" }
+          %select#mod_attack_vector{ :name => "mod_attack_vector", "data-cvss-tag" => "MAV" }
             - options.mod_attack_vector.each do |mod_attack_vector|
               %option #{mod_attack_vector}
-      .control-group
-        %label{ :class => "control-label", :for => "mod_attack_complexity" } Modified Attack Complexity
+      .control-group.cvss3
+        %label.control-label{ :for => "mod_attack_complexity" } Modified Attack Complexity
         .controls
-          %select{ :name => "mod_attack_complexity", :id => "mod_attack_complexity"  }
+          %select#mod_attack_complexity{ :name => "mod_attack_complexity", "data-cvss-tag" => "MAC" }
             - options.mod_attack_complexity.each do |mod_attack_complexity|
               %option #{mod_attack_complexity}
-      .control-group
-        %label{ :class => "control-label", :for => "mod_privileges_required" } Modified Privileges Required
+      .control-group.cvss3
+        %label.control-label{ :for => "mod_privileges_required" } Modified Privileges Required
         .controls
-          %select{ :name => "mod_privileges_required", :id => "mod_privileges_required" }
+          %select#mod_privileges_required{ :name => "mod_privileges_required", "data-cvss-tag" => "MPR" }
             - options.mod_privileges_required.each do |mod_privileges_required|
               %option #{mod_privileges_required}
-      .control-group
-        %label{ :class => "control-label", :for => "mod_user_interaction" } Modified User Interaction
+      .control-group.cvss3
+        %label.control-label{ :for => "mod_user_interaction" } Modified User Interaction
         .controls
-          %select{ :name => "mod_user_interaction", :id => "mod_user_interaction" }
+          %select#mod_user_interaction{ :name => "mod_user_interaction", "data-cvss-tag" => "MUI" }
             - options.mod_user_interaction.each do |mod_user_interaction|
               %option #{mod_user_interaction}
-      .control-group
-        %label{ :class => "control-label", :for => "mod_scope" } Modified Scope
+      .control-group.cvss3
+        %label.control-label{ :for => "mod_scope" } Modified Scope
         .controls
-          %select{ :name => "mod_scope", :id => "mod_scope" }
+          %select#mod_scope{ :name => "mod_scope", "data-cvss-tag" => "MS" }
             - options.mod_scope.each do |mod_scope|
               %option #{mod_scope}
-      .control-group
-        %label{ :class => "control-label", :for => "mod_confidentiality" } Modified Confidentiality
+      .control-group.cvss3
+        %label.control-label{ :for => "mod_confidentiality" } Modified Confidentiality
         .controls
-          %select{ :name => "mod_confidentiality", :id => "mod_confidentiality" }
+          %select#mod_confidentiality{ :name => "mod_confidentiality", "data-cvss-tag" => "MC" }
             - options.mod_confidentiality.each do |mod_confidentiality|
               %option #{mod_confidentiality}
-      .control-group
-        %label{ :class => "control-label", :for => "mod_integrity" } Modified Integrity
+      .control-group.cvss3
+        %label.control-label{ :for => "mod_integrity" } Modified Integrity
         .controls
-          %select{ :name => "mod_integrity", :id => "mod_integrity" }
+          %select#mod_integrity{ :name => "mod_integrity", "data-cvss-tag" => "MI" }
             - options.mod_integrity.each do |mod_integrity|
               %option #{mod_integrity}
-      .control-group
-        %label{ :class => "control-label", :for => "mod_availability" } Modified Availability
+      .control-group.cvss3
+        %label.control-label{ :for => "mod_availability" } Modified Availability
         .controls
-          %select{ :name => "mod_availability", :id => "mod_availability" }
+          %select#mod_availability{ :name => "mod_availability", "data-cvss-tag" => "MA" }
             - options.mod_availability.each do |mod_availability|
               %option #{mod_availability}
     - elsif @riskmatrix
       .control-group
-        %label{ :class => "control-label", :for => "risk" } Vulnerability Risk Level
+        %label.control-label{ :for => "risk" } Vulnerability Risk Level
         .controls
           %select{ :name => "risk" }
             %option{:value => 0}= "None"
@@ -1174,29 +849,29 @@
             %option{:value => 3}= "High"
             %option{:value => 4}= "Critical"
       .control-group
-        %label{ :class => "control-label", :for => "severity" } Severity
+        %label.control-label{ :for => "severity" } Severity
         .controls
           %select{ :name => "severity" }
             - options.severity.each do |severity|
               %option #{severity}
       .control-group
-        %label{ :class => "control-label", :for => "severity_rationale" } Severity Rationale
+        %label.control-label{ :for => "severity_rationale" } Severity Rationale
         .controls
           %textarea{ :rows => '3', :class => 'input-xxlarge allowMarkupShortcut', :id => 'severity_rationale', :name => 'severity_rationale'}
       .control-group
-        %label{ :class => "control-label", :for => "likelihood" } Likelihood
+        %label.control-label{ :for => "likelihood" } Likelihood
         .controls
           %select{ :name => "likelihood" }
             - options.likelihood.each do |likelihood|
               %option #{likelihood}
       .control-group
-        %label{ :class => "control-label", :for => "likelihood_rationale" } Likelihood Rationale
+        %label.control-label{ :for => "likelihood_rationale" } Likelihood Rationale
         .controls
           %textarea{ :rows => '3', :class => 'input-xxlarge allowMarkupShortcut', :id => 'likelihood_rationale', :name => 'likelihood_rationale'}
 
     - else
       .control-group
-        %label{ :class => "control-label", :for => "effort" } Remediation Effort
+        %label.control-label{ :for => "effort" } Remediation Effort
         .controls
           %select{ :name => "effort" }
             - if @finding
@@ -1209,7 +884,7 @@
               - options.effort.each do |effort|
                 %option #{effort}
       .control-group
-        %label{ :class => "control-label", :for => "risk" } Vulnerability Risk Level
+        %label.control-label{ :for => "risk" } Vulnerability Risk Level
         .controls
           %select{ :name => "risk" }
             %option{:value => 0}= "Informational"
@@ -1218,7 +893,7 @@
             %option{:value => 3}= "High"
             %option{:value => 4}= "Critical"
     .control-group
-      %label{ :class => "control-label", :for => "overview" }
+      %label.control-label{ :for => "overview" }
         %a{:href=> '#modaloverview', "data-toggle"=>'modal', :class=>'btn btn-info'}
           Overview
       .modal{:id=>'modaloverview', :class=>'modal hide fade', :tabindex=>'-1', :role=>'dialog', "aria-labelledby"=>'modal-label', "aria-hidden"=>'true'}
@@ -1278,7 +953,7 @@
       .controls
         %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :id => 'overview', :name => 'overview'}
     .control-group
-      %label{ :class => "control-label", :for => "pocu" } Proof of Concept
+      %label.control-label{ :for => "pocu" } Proof of Concept
       .controls
         %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :id => 'poc', :name => 'poc', :id => 'pocu'}
     - attachments=''
@@ -1305,20 +980,20 @@
         })
     - if !@master
       .control-group
-        %label{ :class => "control-label", :for => "affected_hosts" } Affected Hosts
+        %label.control-label{ :for => "affected_hosts" } Affected Hosts
         .controls
           %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :id => 'affected_hosts', :name => 'affected_hosts'}
     .control-group
-      %label{ :class => "control-label", :for => "remediation" } Remediation
+      %label.control-label{ :for => "remediation" } Remediation
       .controls
         %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :name => 'remediation'}
     .control-group
-      %label{ :class => "control-label", :for => "references" } References (One Per Line)
+      %label.control-label{ :for => "references" } References (One Per Line)
       .controls
         %textarea{ :rows => '5', :class => 'input-xxlarge allowMarkupShortcut', :name => 'references'}
     - if !@master
       .control-group
-        %label{ :class => "control-label", :for => "notes" } Notes Data
+        %label.control-label{ :for => "notes" } Notes Data
         %i{:class=>"icon-chevron-down", "data-toggle"=>"collapse", "data-target"=>"#info_2", :id=>"actionButton"}
         .info{ :id => "info_2", :class => "collapse out" }
           %label
@@ -1330,7 +1005,7 @@
                 #{meta_markup(@finding.notes)}
     - if !@master
       .control-group
-        %label{ :class => "control-label", :for => "preso" } Presentation Data
+        %label.control-label{ :for => "preso" } Presentation Data
         %i{:class=>"icon-chevron-down", "data-toggle"=>"collapse", "data-target"=>"#info_1", :id=>"actionButton"}
         .info{ :id => "info_1", :class => "collapse out" }
           %label
@@ -1352,3 +1027,396 @@
     %input{:type => 'submit', :value => 'Save'}
     %a{ :href => "#{id_r}"}
       %input{ :type => "button", :value => 'Cancel'}
+
+  -if @cvssv3
+    :css
+      .cvss3 .cvssjs .results {
+        padding: 0px;
+      }
+
+    :javascript
+      var cvssjs;
+
+      function updateCVSS() {
+        updateCVSSSummary(true);
+      }
+
+      function updateCVSSSummary(updateCVSSJS) {
+        var vectorString = "CVSS:3.0";
+
+        $("select[data-cvss-tag]").each(function (index, element) {
+          if (element.value.toLowerCase() == "not defined") {
+            vectorString += "/" + element.getAttribute("data-cvss-tag") + ":X";
+          } else {
+            vectorString += "/" + element.getAttribute("data-cvss-tag") + ":" + element.value[0];
+          }
+        });
+        var output = CVSS.calculateCVSSFromVector(vectorString);
+
+        $("#baseScore .results .score").text(output.baseMetricScore);
+        $("#baseScore .results .severity").text(output.baseSeverity);
+        $("#baseScore .results .severity").attr("class", "severity " + output.baseSeverity);
+        $("#temporalScore .results .score").text(output.temporalMetricScore);
+        $("#temporalScore .results .severity").text(output.temporalSeverity);
+        $("#temporalScore .results .severity").attr("class", "severity " + output.temporalSeverity);
+        $("#environmentalScore .results .score").text(output.environmentalMetricScore);
+        $("#environmentalScore .results .severity").text(output.environmentalSeverity);
+        $("#environmentalScore .results .severity").attr("class", "severity " + output.environmentalSeverity);
+
+        if (updateCVSSJS) {
+          cvssjs.set(vectorString);
+        }
+      }
+
+      function updateDropdown(score){
+        var vector = score.trim().split("/");
+
+        for(var i in vector){
+          var part = vector[i];
+
+          if (part.length > 0){
+            part = part.toUpperCase();
+          }
+
+          //CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N/RL:O/CR:L
+          // AV
+          // LANP
+          if(part.includes("AV:") && !part.includes("MAV:")){
+            if(part.includes(":L")){
+              document.getElementById('attack_vector').selectedIndex=0;
+            }
+            if(part.includes(":A")){
+              document.getElementById('attack_vector').selectedIndex=1;
+            }
+            if(part.includes(":N")){
+              document.getElementById('attack_vector').selectedIndex=2;
+            }
+            if(part.includes(":P")){
+              document.getElementById('attack_vector').selectedIndex=3;
+            }
+          }
+
+          // AC
+          if(part.includes("AC:")  && !part.includes("MAC:")){
+            if(part.includes(":L")){
+              document.getElementById('attack_complexity').selectedIndex=0;
+            }
+            if(part.includes(":H")){
+              document.getElementById('attack_complexity').selectedIndex=1;
+            }
+          }
+
+          // PR NLH
+          if(part.includes("PR:")  && !part.includes("MPR:")){
+            if(part.includes(":N")){
+              document.getElementById('privileges_required').selectedIndex=0;
+            }
+            if(part.includes(":L")){
+              document.getElementById('privileges_required').selectedIndex=1;
+            }
+            if(part.includes(":H")){
+              document.getElementById('privileges_required').selectedIndex=2;
+            }
+          }
+
+          // UI
+          if(part.includes("UI:")){
+            if(part.includes(":N")){
+              document.getElementById('user_interaction').selectedIndex=0;
+            }
+            if(part.includes(":R")){
+              document.getElementById('user_interaction').selectedIndex=1;
+            }
+          }
+
+          // S
+          if(part.includes("S:")  && !part.includes("MS:")){
+            if(part.includes(":U")){
+              document.getElementById('scope').selectedIndex=0;
+            }
+            if(part.includes(":C")){
+              document.getElementById('scope').selectedIndex=1;
+            }
+          }
+
+          // I
+          if(part.includes("I:")  && !part.includes("MI:")){
+            if(part.includes(":N")){
+              document.getElementById('integrity').selectedIndex=0;
+            }
+            if(part.includes(":L")){
+              document.getElementById('integrity').selectedIndex=1;
+            }
+            if(part.includes(":H")){
+              document.getElementById('integrity').selectedIndex=2;
+            }
+          }
+
+          // C
+          if(part.includes("C:") && !part.includes("MC:") && !part.includes("MAC:")){
+            if(part.includes(":N")){
+              document.getElementById('confidentiality-impact').selectedIndex=0;
+            }
+            if(part.includes(":L")){
+              document.getElementById('confidentiality-impact').selectedIndex=1;
+            }
+            if(part.includes(":H")){
+              document.getElementById('confidentiality-impact').selectedIndex=2;
+            }
+          }
+
+          // A
+          if(part.includes("A:")  && !part.includes("MA:")){
+            if(part.includes(":N")){
+              document.getElementById('availability').selectedIndex=0;
+            }
+            if(part.includes(":L")){
+              document.getElementById('availability').selectedIndex=1;
+            }
+            if(part.includes(":H")){
+              document.getElementById('availability').selectedIndex=2;
+            }
+          }
+
+          // Exploit Code Maturity
+          if(part.includes("E:")){
+            if(part.includes(":X")){
+              document.getElementById('exploit_maturity').selectedIndex=0;
+            }
+            if(part.includes(":U")){
+              document.getElementById('exploit_maturity').selectedIndex=1;
+            }
+            if(part.includes(":P")){
+              document.getElementById('exploit_maturity').selectedIndex=2;
+            }
+            if(part.includes(":F")){
+              document.getElementById('exploit_maturity').selectedIndex=3;
+            }
+          }
+
+
+          // Remediation Level
+          if(part.includes("RL:")){
+            if(part.includes(":X")){
+              document.getElementById('remeditation_level').selectedIndex=0;
+            }
+            if(part.includes(":O")){
+              document.getElementById('remeditation_level').selectedIndex=1;
+            }
+            if(part.includes(":T")){
+              document.getElementById('remeditation_level').selectedIndex=2;
+            }
+            if(part.includes(":W")){
+              document.getElementById('remeditation_level').selectedIndex=3;
+            }
+            if(part.includes(":U")){
+              document.getElementById('remeditation_level').selectedIndex=4;
+            }
+          }
+
+
+          // report confidence
+          if(part.includes("RC:")){
+            if(part.includes(":X")){
+              document.getElementById('report_confidence').selectedIndex=0;
+            }
+            if(part.includes(":U")){
+              document.getElementById('report_confidence').selectedIndex=1;
+            }
+            if(part.includes(":R")){
+              document.getElementById('report_confidence').selectedIndex=2;
+            }
+            if(part.includes(":C")){
+              document.getElementById('report_confidence').selectedIndex=3;
+            }
+          }
+
+          // confidentiality-requirement
+          if(part.includes("CR:")){
+            if(part.includes(":X")){
+              document.getElementById('confidentiality_requirement').selectedIndex=0;
+            }
+            if(part.includes(":L")){
+              document.getElementById('confidentiality_requirement').selectedIndex=1;
+            }
+            if(part.includes(":M")){
+              document.getElementById('confidentiality_requirement').selectedIndex=2;
+            }
+            if(part.includes(":H")){
+              document.getElementById('confidentiality_requirement').selectedIndex=3;
+            }
+          }
+
+          // integrity-requirement
+          if(part.includes("IR:")){
+            if(part.includes(":X")){
+              document.getElementById('integrity_requirement').selectedIndex=0;
+            }
+            if(part.includes(":L")){
+              document.getElementById('integrity_requirement').selectedIndex=1;
+            }
+            if(part.includes(":M")){
+              document.getElementById('integrity_requirement').selectedIndex=2;
+            }
+            if(part.includes(":H")){
+              document.getElementById('integrity_requirement').selectedIndex=3;
+            }
+          }
+
+          // integrity-requirement
+          if(part.includes("AR:")){
+            if(part.includes(":X")){
+              document.getElementById('availability_requirement').selectedIndex=0;
+            }
+            if(part.includes(":L")){
+              document.getElementById('availability_requirement').selectedIndex=1;
+            }
+            if(part.includes(":M")){
+              document.getElementById('availability_requirement').selectedIndex=2;
+            }
+            if(part.includes(":H")){
+              document.getElementById('availability_requirement').selectedIndex=3;
+            }
+          }
+
+          // modified-attack-vector
+          if(part.includes("MAV:")){
+            if(part.includes(":X")){
+              document.getElementById('mod_attack_vector').selectedIndex=0;
+            }
+            if(part.includes(":L")){
+              document.getElementById('mod_attack_vector').selectedIndex=1;
+            }
+            if(part.includes(":A")){
+              document.getElementById('mod_attack_vector').selectedIndex=2;
+            }
+            if(part.includes(":N")){
+              document.getElementById('mod_attack_vector').selectedIndex=3;
+            }
+            if(part.includes(":P")){
+              document.getElementById('mod_attack_vector').selectedIndex=4;
+            }
+          }
+
+          // modified-attack-vector
+          if(part.includes("MAC:")){
+            if(part.includes(":X")){
+              document.getElementById('mod_attack_complexity').selectedIndex=0;
+            }
+            if(part.includes(":L")){
+              document.getElementById('mod_attack_complexity').selectedIndex=1;
+            }
+            if(part.includes(":H")){
+              document.getElementById('mod_attack_complexity').selectedIndex=2;
+            }
+          }
+
+          // modified-privileges-Required
+          if(part.includes("MPR:")){
+            if(part.includes(":X")){
+              document.getElementById('mod_privileges_required').selectedIndex=0;
+            }
+            if(part.includes(":N")){
+              document.getElementById('mod_privileges_required').selectedIndex=1;
+            }
+            if(part.includes(":L")){
+              document.getElementById('mod_privileges_required').selectedIndex=2;
+            }
+            if(part.includes(":H")){
+              document.getElementById('mod_privileges_required').selectedIndex=3;
+            }
+          }
+
+          // modified-user-interaction
+          if(part.includes("MUI:")){
+            if(part.includes(":X")){
+              document.getElementById('mod_user_interaction').selectedIndex=0;
+            }
+            if(part.includes(":N")){
+              document.getElementById('mod_user_interaction').selectedIndex=1;
+            }
+            if(part.includes(":R")){
+              document.getElementById('mod_user_interaction').selectedIndex=2;
+            }
+          }
+
+          // modified-scope
+          if(part.includes("MS:")){
+            if(part.includes(":X")){
+              document.getElementById('mod_scope').selectedIndex=0;
+            }
+            if(part.includes(":U")){
+              document.getElementById('mod_scope').selectedIndex=1;
+            }
+            if(part.includes(":C")){
+              document.getElementById('mod_scope').selectedIndex=2;
+            }
+          }
+
+          // modified-confidentiality
+          if(part.includes("MC:")){
+            if(part.includes(":X")){
+              document.getElementById('mod_confidentiality').selectedIndex=0;
+            }
+            if(part.includes(":N")){
+              document.getElementById('mod_confidentiality').selectedIndex=1;
+            }
+            if(part.includes(":L")){
+              document.getElementById('mod_confidentiality').selectedIndex=2;
+            }
+            if(part.includes(":H")){
+              document.getElementById('mod_confidentiality').selectedIndex=3;
+            }
+          }
+
+          // modified-integrity
+          if(part.includes("MI:")){
+            if(part.includes(":X")){
+              document.getElementById('mod_integrity').selectedIndex=0;
+            }
+            if(part.includes(":N")){
+              document.getElementById('mod_integrity').selectedIndex=1;
+            }
+            if(part.includes(":L")){
+              document.getElementById('mod_integrity').selectedIndex=2;
+            }
+            if(part.includes(":H")){
+              document.getElementById('mod_integrity').selectedIndex=3;
+            }
+          }
+
+          // modified-availability
+          if(part.includes("MA:")){
+            if(part.includes(":X")){
+              document.getElementById('mod_availability').selectedIndex=0;
+            }
+            if(part.includes(":N")){
+              document.getElementById('mod_availability').selectedIndex=1;
+            }
+            if(part.includes(":L")){
+              document.getElementById('mod_availability').selectedIndex=2;
+            }
+            if(part.includes(":H")){
+              document.getElementById('mod_availability').selectedIndex=3;
+            }
+          }
+        }
+      }
+
+      $(document).ready(function() {
+        cvssjs = new CVSS.js("cvssboard", {
+          onchange: function() {
+            document.getElementById('vs').value = cvssjs.get().vector;
+            updateDropdown(cvssjs.get().vector);
+            updateCVSSSummary(false);
+          }
+        });
+
+        $(".cvss3 select").on("change", updateCVSS);
+        updateCVSSSummary(true);
+
+        $("#vs").on('change keydown paste input', function(){
+          updateDropdown(this.value);
+          updateCVSSSummary(true, false);
+        });
+      });

--- a/views/create_finding.haml
+++ b/views/create_finding.haml
@@ -91,222 +91,222 @@
                 // AV
                 if(part.includes("AV:")){
                 if(part.includes(":L")){
-                document.getElementById('av').selectedIndex=0;        
+                document.getElementById('av').selectedIndex=0;
                 }
                 if(part.includes(":A")){
-                document.getElementById('av').selectedIndex=1;        
+                document.getElementById('av').selectedIndex=1;
                 }
                 if(part.includes(":N")){
-                document.getElementById('av').selectedIndex=2;        
+                document.getElementById('av').selectedIndex=2;
                 }
-                }        
+                }
 
                 // AC
                 if(part.includes("AC:")){
                 if(part.includes(":H")){
-                document.getElementById('ac').selectedIndex=0;        
+                document.getElementById('ac').selectedIndex=0;
                 }
                 if(part.includes(":M")){
-                document.getElementById('ac').selectedIndex=1;        
+                document.getElementById('ac').selectedIndex=1;
                 }
                 if(part.includes(":L")){
-                document.getElementById('ac').selectedIndex=2;        
+                document.getElementById('ac').selectedIndex=2;
                 }
-                }        
+                }
 
                 // AU
                 if(part.includes("AU:")){
                 if(part.includes(":M")){
-                document.getElementById('au').selectedIndex=0;        
+                document.getElementById('au').selectedIndex=0;
                 }
                 if(part.includes(":S")){
-                document.getElementById('au').selectedIndex=1;        
+                document.getElementById('au').selectedIndex=1;
                 }
                 if(part.includes(":N")){
-                document.getElementById('au').selectedIndex=2;        
+                document.getElementById('au').selectedIndex=2;
                 }
-                }        
+                }
 
                 // C
                 if(part.includes("C:") && !part.includes("AC:")){
                 if(part.includes(":N")){
-                document.getElementById('c').selectedIndex=0;        
+                document.getElementById('c').selectedIndex=0;
                 }
                 if(part.includes(":P")){
-                document.getElementById('c').selectedIndex=1;        
+                document.getElementById('c').selectedIndex=1;
                 }
                 if(part.includes(":C")){
-                document.getElementById('c').selectedIndex=2;        
+                document.getElementById('c').selectedIndex=2;
                 }
-                }        
+                }
 
                 // I
                 if(part.includes("I:")){
                 if(part.includes(":N")){
-                document.getElementById('i').selectedIndex=0;        
+                document.getElementById('i').selectedIndex=0;
                 }
                 if(part.includes(":P")){
-                document.getElementById('i').selectedIndex=1;        
+                document.getElementById('i').selectedIndex=1;
                 }
                 if(part.includes(":C")){
-                document.getElementById('i').selectedIndex=2;        
+                document.getElementById('i').selectedIndex=2;
                 }
-                }        
+                }
 
                 // A
                 if(part.includes("A:")){
                 if(part.includes(":N")){
-                document.getElementById('a').selectedIndex=0;        
+                document.getElementById('a').selectedIndex=0;
                 }
                 if(part.includes(":P")){
-                document.getElementById('a').selectedIndex=1;        
+                document.getElementById('a').selectedIndex=1;
                 }
                 if(part.includes(":C")){
-                document.getElementById('a').selectedIndex=2;        
+                document.getElementById('a').selectedIndex=2;
                 }
-                }        
+                }
 
                 // E
                 if(part.includes("E:")){
                 if(part.includes(":ND")){
-                document.getElementById('e').selectedIndex=0;        
+                document.getElementById('e').selectedIndex=0;
                 }
                 if(part.includes(":U")){
-                document.getElementById('e').selectedIndex=1;        
+                document.getElementById('e').selectedIndex=1;
                 }
                 if(part.includes(":POC")){
-                document.getElementById('e').selectedIndex=2;        
+                document.getElementById('e').selectedIndex=2;
                 }
                 if(part.includes(":F")){
-                document.getElementById('e').selectedIndex=3;        
+                document.getElementById('e').selectedIndex=3;
                 }
                 if(part.includes(":H")){
-                document.getElementById('e').selectedIndex=4;        
+                document.getElementById('e').selectedIndex=4;
                 }
-                }        
+                }
 
                 // RL
                 if(part.includes("RL:")){
                 if(part.includes(":ND")){
-                document.getElementById('rl').selectedIndex=0;        
+                document.getElementById('rl').selectedIndex=0;
                 }
                 if(part.includes(":OF")){
-                document.getElementById('rl').selectedIndex=1;        
+                document.getElementById('rl').selectedIndex=1;
                 }
                 if(part.includes(":TF")){
-                document.getElementById('rl').selectedIndex=2;        
+                document.getElementById('rl').selectedIndex=2;
                 }
                 if(part.includes(":W")){
-                document.getElementById('rl').selectedIndex=3;        
+                document.getElementById('rl').selectedIndex=3;
                 }
                 if(part.includes(":U")){
-                document.getElementById('rl').selectedIndex=4;        
+                document.getElementById('rl').selectedIndex=4;
                 }
-                }        
+                }
 
                 // RC
                 if(part.includes("RC:")){
                 if(part.includes(":ND")){
-                document.getElementById('rc').selectedIndex=0;        
+                document.getElementById('rc').selectedIndex=0;
                 }
                 if(part.includes(":UC")){
-                document.getElementById('rc').selectedIndex=1;        
+                document.getElementById('rc').selectedIndex=1;
                 }
                 if(part.includes(":UR")){
-                document.getElementById('rc').selectedIndex=2;        
+                document.getElementById('rc').selectedIndex=2;
                 }
                 if(part.includes(":C")){
-                document.getElementById('rc').selectedIndex=3;        
+                document.getElementById('rc').selectedIndex=3;
                 }
-                }        
+                }
 
                 // CDP
                 if(part.includes("CDP:")){
                 if(part.includes(":ND")){
-                document.getElementById('cdp').selectedIndex=0;        
+                document.getElementById('cdp').selectedIndex=0;
                 }
                 if(part.includes(":N")){
-                document.getElementById('cdp').selectedIndex=1;        
+                document.getElementById('cdp').selectedIndex=1;
                 }
                 if(part.includes(":LM")){
-                document.getElementById('cdp').selectedIndex=2;        
+                document.getElementById('cdp').selectedIndex=2;
                 }
                 if(part.includes(":MH")){
-                document.getElementById('cdp').selectedIndex=3;        
+                document.getElementById('cdp').selectedIndex=3;
                 }
                 if(part.includes(":H")){
-                document.getElementById('cdp').selectedIndex=4;        
+                document.getElementById('cdp').selectedIndex=4;
                 }
-                }        
+                }
 
                 // TD
                 if(part.includes("TD:")){
                 if(part.includes(":ND")){
-                document.getElementById('td').selectedIndex=0;        
+                document.getElementById('td').selectedIndex=0;
                 }
                 if(part.includes(":N")){
-                document.getElementById('td').selectedIndex=1;        
+                document.getElementById('td').selectedIndex=1;
                 }
                 if(part.includes(":L")){
-                document.getElementById('td').selectedIndex=2;        
+                document.getElementById('td').selectedIndex=2;
                 }
                 if(part.includes(":M")){
-                document.getElementById('td').selectedIndex=3;        
+                document.getElementById('td').selectedIndex=3;
                 }
                 if(part.includes(":H")){
-                document.getElementById('td').selectedIndex=4;        
+                document.getElementById('td').selectedIndex=4;
                 }
-                }        
+                }
 
                 // CD
                 if(part.includes("CR:")){
                 if(part.includes(":ND")){
-                document.getElementById('cd').selectedIndex=0;        
+                document.getElementById('cd').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('cd').selectedIndex=1;        
+                document.getElementById('cd').selectedIndex=1;
                 }
                 if(part.includes(":M")){
-                document.getElementById('cd').selectedIndex=2;        
+                document.getElementById('cd').selectedIndex=2;
                 }
                 if(part.includes(":H")){
-                document.getElementById('cd').selectedIndex=3;        
+                document.getElementById('cd').selectedIndex=3;
                 }
-                }        
+                }
 
                 // IR
                 if(part.includes("IR:")){
                 if(part.includes(":ND")){
-                document.getElementById('ir').selectedIndex=0;        
+                document.getElementById('ir').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('ir').selectedIndex=1;        
+                document.getElementById('ir').selectedIndex=1;
                 }
                 if(part.includes(":M")){
-                document.getElementById('ir').selectedIndex=2;        
+                document.getElementById('ir').selectedIndex=2;
                 }
                 if(part.includes(":H")){
-                document.getElementById('ir').selectedIndex=3;        
+                document.getElementById('ir').selectedIndex=3;
                 }
-                }        
+                }
 
                 // AR
                 if(part.includes("AR:")){
                 if(part.includes(":ND")){
-                document.getElementById('ar').selectedIndex=0;        
+                document.getElementById('ar').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('ar').selectedIndex=1;        
+                document.getElementById('ar').selectedIndex=1;
                 }
                 if(part.includes(":M")){
-                document.getElementById('ar').selectedIndex=2;        
+                document.getElementById('ar').selectedIndex=2;
                 }
                 if(part.includes(":H")){
-                document.getElementById('ar').selectedIndex=3;        
+                document.getElementById('ar').selectedIndex=3;
                 }
-                }        
+                }
                 }}
-                var c = new CVSS("cvssboard", {
+                var c = new CVSS.js("cvssboard", {
                 onchange: function() {
                 window.location.hash = c.get().vector;
                 document.getElementById('vs').value = c.get().vector;
@@ -314,11 +314,11 @@
                 }
                 });
 
-                $("#vs").on('change keydown paste input', function(){               
-                updateDropdown(this.value);                
+                $("#vs").on('change keydown paste input', function(){
+                updateDropdown(this.value);
                 });
         .controls
-          %input{:type => "text", :class=>"form-control", :placeholder=>"CVSS Vector String", :id=>"vs", :style=>"width:35em"}  
+          %input{:type => "text", :class=>"form-control", :placeholder=>"CVSS Vector String", :id=>"vs", :style=>"width:35em"}
       .control-group
         %label{ :class => "control-label", :for => "av" } Access Vector
         .controls
@@ -441,220 +441,220 @@
         // AV
         if(part.includes("AV:")){
         if(part.includes(":L")){
-        document.getElementById('av').selectedIndex=0;        
+        document.getElementById('av').selectedIndex=0;
         }
         if(part.includes(":A")){
-        document.getElementById('av').selectedIndex=1;        
+        document.getElementById('av').selectedIndex=1;
         }
         if(part.includes(":N")){
-        document.getElementById('av').selectedIndex=2;        
+        document.getElementById('av').selectedIndex=2;
         }
-        }        
+        }
 
         // AC
         if(part.includes("AC:")){
         if(part.includes(":H")){
-        document.getElementById('ac').selectedIndex=0;        
+        document.getElementById('ac').selectedIndex=0;
         }
         if(part.includes(":M")){
-        document.getElementById('ac').selectedIndex=1;        
+        document.getElementById('ac').selectedIndex=1;
         }
         if(part.includes(":L")){
-        document.getElementById('ac').selectedIndex=2;        
+        document.getElementById('ac').selectedIndex=2;
         }
-        }        
+        }
 
         // AU
         if(part.includes("AU:")){
         if(part.includes(":M")){
-        document.getElementById('au').selectedIndex=0;        
+        document.getElementById('au').selectedIndex=0;
         }
         if(part.includes(":S")){
-        document.getElementById('au').selectedIndex=1;        
+        document.getElementById('au').selectedIndex=1;
         }
         if(part.includes(":N")){
-        document.getElementById('au').selectedIndex=2;        
+        document.getElementById('au').selectedIndex=2;
         }
-        }        
+        }
 
         // C
         if(part.includes("C:")){
         if(part.includes(":N")){
-        document.getElementById('c').selectedIndex=0;        
+        document.getElementById('c').selectedIndex=0;
         }
         if(part.includes(":P")){
-        document.getElementById('c').selectedIndex=1;        
+        document.getElementById('c').selectedIndex=1;
         }
         if(part.includes(":C")){
-        document.getElementById('c').selectedIndex=2;        
+        document.getElementById('c').selectedIndex=2;
         }
-        }        
+        }
 
         // I
         if(part.includes("I:")){
         if(part.includes(":N")){
-        document.getElementById('i').selectedIndex=0;        
+        document.getElementById('i').selectedIndex=0;
         }
         if(part.includes(":P")){
-        document.getElementById('i').selectedIndex=1;        
+        document.getElementById('i').selectedIndex=1;
         }
         if(part.includes(":C")){
-        document.getElementById('i').selectedIndex=2;        
+        document.getElementById('i').selectedIndex=2;
         }
-        }        
+        }
 
         // A
         if(part.includes("A:")){
         if(part.includes(":N")){
-        document.getElementById('a').selectedIndex=0;        
+        document.getElementById('a').selectedIndex=0;
         }
         if(part.includes(":P")){
-        document.getElementById('a').selectedIndex=1;        
+        document.getElementById('a').selectedIndex=1;
         }
         if(part.includes(":C")){
-        document.getElementById('a').selectedIndex=2;        
+        document.getElementById('a').selectedIndex=2;
         }
-        }        
+        }
 
         // E
         if(part.includes("E:")){
         if(part.includes(":ND")){
-        document.getElementById('e').selectedIndex=0;        
+        document.getElementById('e').selectedIndex=0;
         }
         if(part.includes(":U")){
-        document.getElementById('e').selectedIndex=1;        
+        document.getElementById('e').selectedIndex=1;
         }
         if(part.includes(":POC")){
-        document.getElementById('e').selectedIndex=2;        
+        document.getElementById('e').selectedIndex=2;
         }
         if(part.includes(":F")){
-        document.getElementById('e').selectedIndex=3;        
+        document.getElementById('e').selectedIndex=3;
         }
         if(part.includes(":H")){
-        document.getElementById('e').selectedIndex=4;        
+        document.getElementById('e').selectedIndex=4;
         }
-        }        
+        }
 
         // RL
         if(part.includes("RL:")){
         if(part.includes(":ND")){
-        document.getElementById('rl').selectedIndex=0;        
+        document.getElementById('rl').selectedIndex=0;
         }
         if(part.includes(":OF")){
-        document.getElementById('rl').selectedIndex=1;        
+        document.getElementById('rl').selectedIndex=1;
         }
         if(part.includes(":TF")){
-        document.getElementById('rl').selectedIndex=2;        
+        document.getElementById('rl').selectedIndex=2;
         }
         if(part.includes(":W")){
-        document.getElementById('rl').selectedIndex=3;        
+        document.getElementById('rl').selectedIndex=3;
         }
         if(part.includes(":U")){
-        document.getElementById('rl').selectedIndex=4;        
+        document.getElementById('rl').selectedIndex=4;
         }
-        }        
+        }
 
         // RC
         if(part.includes("RC:")){
         if(part.includes(":ND")){
-        document.getElementById('rc').selectedIndex=0;        
+        document.getElementById('rc').selectedIndex=0;
         }
         if(part.includes(":UC")){
-        document.getElementById('rc').selectedIndex=1;        
+        document.getElementById('rc').selectedIndex=1;
         }
         if(part.includes(":UR")){
-        document.getElementById('rc').selectedIndex=2;        
+        document.getElementById('rc').selectedIndex=2;
         }
         if(part.includes(":C")){
-        document.getElementById('rc').selectedIndex=3;        
+        document.getElementById('rc').selectedIndex=3;
         }
-        }        
+        }
 
         // CDP
         if(part.includes("CDP:")){
         if(part.includes(":ND")){
-        document.getElementById('cdp').selectedIndex=0;        
+        document.getElementById('cdp').selectedIndex=0;
         }
         if(part.includes(":N")){
-        document.getElementById('cdp').selectedIndex=1;        
+        document.getElementById('cdp').selectedIndex=1;
         }
         if(part.includes(":LM")){
-        document.getElementById('cdp').selectedIndex=2;        
+        document.getElementById('cdp').selectedIndex=2;
         }
         if(part.includes(":MH")){
-        document.getElementById('cdp').selectedIndex=3;        
+        document.getElementById('cdp').selectedIndex=3;
         }
         if(part.includes(":H")){
-        document.getElementById('cdp').selectedIndex=4;        
+        document.getElementById('cdp').selectedIndex=4;
         }
-        }        
+        }
 
         // TD
         if(part.includes("TD:")){
         if(part.includes(":ND")){
-        document.getElementById('td').selectedIndex=0;        
+        document.getElementById('td').selectedIndex=0;
         }
         if(part.includes(":N")){
-        document.getElementById('td').selectedIndex=1;        
+        document.getElementById('td').selectedIndex=1;
         }
         if(part.includes(":L")){
-        document.getElementById('td').selectedIndex=2;        
+        document.getElementById('td').selectedIndex=2;
         }
         if(part.includes(":M")){
-        document.getElementById('td').selectedIndex=3;        
+        document.getElementById('td').selectedIndex=3;
         }
         if(part.includes(":H")){
-        document.getElementById('td').selectedIndex=4;        
+        document.getElementById('td').selectedIndex=4;
         }
-        }        
+        }
 
         // CD
         if(part.includes("CR:")){
         if(part.includes(":ND")){
-        document.getElementById('cd').selectedIndex=0;        
+        document.getElementById('cd').selectedIndex=0;
         }
         if(part.includes(":L")){
-        document.getElementById('cd').selectedIndex=1;        
+        document.getElementById('cd').selectedIndex=1;
         }
         if(part.includes(":M")){
-        document.getElementById('cd').selectedIndex=2;        
+        document.getElementById('cd').selectedIndex=2;
         }
         if(part.includes(":H")){
-        document.getElementById('cd').selectedIndex=3;        
+        document.getElementById('cd').selectedIndex=3;
         }
-        }        
+        }
 
         // IR
         if(part.includes("IR:")){
         if(part.includes(":ND")){
-        document.getElementById('ir').selectedIndex=0;        
+        document.getElementById('ir').selectedIndex=0;
         }
         if(part.includes(":L")){
-        document.getElementById('ir').selectedIndex=1;        
+        document.getElementById('ir').selectedIndex=1;
         }
         if(part.includes(":M")){
-        document.getElementById('ir').selectedIndex=2;        
+        document.getElementById('ir').selectedIndex=2;
         }
         if(part.includes(":H")){
-        document.getElementById('ir').selectedIndex=3;        
+        document.getElementById('ir').selectedIndex=3;
         }
-        }        
+        }
 
         // AR
         if(part.includes("AR:")){
         if(part.includes(":ND")){
-        document.getElementById('ar').selectedIndex=0;        
+        document.getElementById('ar').selectedIndex=0;
         }
         if(part.includes(":L")){
-        document.getElementById('ar').selectedIndex=1;        
+        document.getElementById('ar').selectedIndex=1;
         }
         if(part.includes(":M")){
-        document.getElementById('ar').selectedIndex=2;        
+        document.getElementById('ar').selectedIndex=2;
         }
         if(part.includes(":H")){
-        document.getElementById('ar').selectedIndex=3;        
+        document.getElementById('ar').selectedIndex=3;
         }
-        }        
+        }
 
         }
         });
@@ -665,13 +665,13 @@
             %option QUICK
             %option PLANNED
             %option INVOLVED
-    - elsif @cvssv3      
+    - elsif @cvssv3
       .control-group
         %label{ :class => "control-label", :for => "attack_vector" }
           %a{:href=> '#mymodal', "data-toggle"=>'modal', :class=>'btn btn-info'}
             CVSS Vector String
         .controls
-          %input{:type => "text", :class=>"form-control", :placeholder=>"CVSS Vector String", :id=>"vs", :style=>"width:35em"}  
+          %input{:type => "text", :class=>"form-control", :placeholder=>"CVSS Vector String", :id=>"vs", :style=>"width:35em"}
         .modal{:id=>'mymodal', :class=>'modal hide fade', :tabindex=>'-1', :role=>'dialog', "aria-labelledby"=>'modal-label', "aria-hidden"=>'true'}
           .modal-header
             %button{:type=>'button', :class=>'close', "data-dismiss"=>"modal", "aria-hidden"=>"true"}
@@ -684,7 +684,7 @@
             %div{ :id=>"cvssboard"}
               %script
                 function updateDropdown(score){
-                
+
                 var vector = score.trim().split("/");
                 for(var i in vector){
                 var part = vector[i];
@@ -698,337 +698,337 @@
                 // LANP
                 if(part.includes("AV:") && !part.includes("MAV:")){
                 if(part.includes(":L")){
-                document.getElementById('attack_vector').selectedIndex=0;        
+                document.getElementById('attack_vector').selectedIndex=0;
                 }
                 if(part.includes(":A")){
-                document.getElementById('attack_vector').selectedIndex=1;        
+                document.getElementById('attack_vector').selectedIndex=1;
                 }
                 if(part.includes(":N")){
-                document.getElementById('attack_vector').selectedIndex=2;        
+                document.getElementById('attack_vector').selectedIndex=2;
                 }
                 if(part.includes(":P")){
-                document.getElementById('attack_vector').selectedIndex=3;        
+                document.getElementById('attack_vector').selectedIndex=3;
                 }
-                }        
+                }
 
                 // AC
                 if(part.includes("AC:")  && !part.includes("MAC:")){
                 if(part.includes(":L")){
-                document.getElementById('attack_complexity').selectedIndex=0;        
+                document.getElementById('attack_complexity').selectedIndex=0;
                 }
                 if(part.includes(":H")){
-                document.getElementById('attack_complexity').selectedIndex=1;        
+                document.getElementById('attack_complexity').selectedIndex=1;
                 }
-                }        
+                }
 
                 // PR NLH
                 if(part.includes("PR:")  && !part.includes("MPR:")){
                 if(part.includes(":N")){
-                document.getElementById('privileges_required').selectedIndex=0;        
+                document.getElementById('privileges_required').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('privileges_required').selectedIndex=1;        
+                document.getElementById('privileges_required').selectedIndex=1;
                 }
                 if(part.includes(":H")){
-                document.getElementById('privileges_required').selectedIndex=2;        
+                document.getElementById('privileges_required').selectedIndex=2;
                 }
-                }        
+                }
 
                 // UI
                 if(part.includes("UI:")){
                 if(part.includes(":N")){
-                document.getElementById('user_interaction').selectedIndex=0;        
+                document.getElementById('user_interaction').selectedIndex=0;
                 }
                 if(part.includes(":R")){
-                document.getElementById('user_interaction').selectedIndex=1;        
+                document.getElementById('user_interaction').selectedIndex=1;
                 }
-                }        
+                }
 
                 // S
                 if(part.includes("S:")  && !part.includes("MS:")){
                 if(part.includes(":U")){
-                document.getElementById('scope').selectedIndex=0;        
+                document.getElementById('scope').selectedIndex=0;
                 }
                 if(part.includes(":C")){
-                document.getElementById('scope').selectedIndex=1;        
+                document.getElementById('scope').selectedIndex=1;
                 }
-                }        
+                }
 
                 // I
                 if(part.includes("I:")  && !part.includes("MI:")){
                 if(part.includes(":N")){
-                document.getElementById('integrity').selectedIndex=0;        
+                document.getElementById('integrity').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('integrity').selectedIndex=1;        
+                document.getElementById('integrity').selectedIndex=1;
                 }
                 if(part.includes(":H")){
-                document.getElementById('integrity').selectedIndex=2;        
+                document.getElementById('integrity').selectedIndex=2;
                 }
-                }        
+                }
 
                 // C
                 if(part.includes("C:") && !part.includes("MC:") && !part.includes("MAC:")){
                 if(part.includes(":N")){
-                document.getElementById('confidentiality-impact').selectedIndex=0;        
+                document.getElementById('confidentiality-impact').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('confidentiality-impact').selectedIndex=1;        
+                document.getElementById('confidentiality-impact').selectedIndex=1;
                 }
                 if(part.includes(":H")){
-                document.getElementById('confidentiality-impact').selectedIndex=2;        
+                document.getElementById('confidentiality-impact').selectedIndex=2;
                 }
-                }        
+                }
 
                 // A
                 if(part.includes("A:")  && !part.includes("MA:")){
                 if(part.includes(":N")){
-                document.getElementById('availability').selectedIndex=0;        
+                document.getElementById('availability').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('availability').selectedIndex=1;        
+                document.getElementById('availability').selectedIndex=1;
                 }
                 if(part.includes(":H")){
-                document.getElementById('availability').selectedIndex=2;        
+                document.getElementById('availability').selectedIndex=2;
                 }
-                }        
+                }
 
                 // Exploit Code Maturity
                 if(part.includes("E:")){
                 if(part.includes(":X")){
-                document.getElementById('exploit_maturity').selectedIndex=0;        
+                document.getElementById('exploit_maturity').selectedIndex=0;
                 }
                 if(part.includes(":U")){
-                document.getElementById('exploit_maturity').selectedIndex=1;        
+                document.getElementById('exploit_maturity').selectedIndex=1;
                 }
                 if(part.includes(":P")){
-                document.getElementById('exploit_maturity').selectedIndex=2;        
+                document.getElementById('exploit_maturity').selectedIndex=2;
                 }
                 if(part.includes(":F")){
-                document.getElementById('exploit_maturity').selectedIndex=3;        
+                document.getElementById('exploit_maturity').selectedIndex=3;
                 }
-                }        
+                }
 
 
                 // Remediation Level
                 if(part.includes("RL:")){
                 if(part.includes(":X")){
-                document.getElementById('remeditation_level').selectedIndex=0;        
+                document.getElementById('remeditation_level').selectedIndex=0;
                 }
                 if(part.includes(":O")){
-                document.getElementById('remeditation_level').selectedIndex=1;        
+                document.getElementById('remeditation_level').selectedIndex=1;
                 }
                 if(part.includes(":T")){
-                document.getElementById('remeditation_level').selectedIndex=2;        
+                document.getElementById('remeditation_level').selectedIndex=2;
                 }
                 if(part.includes(":W")){
-                document.getElementById('remeditation_level').selectedIndex=3;        
+                document.getElementById('remeditation_level').selectedIndex=3;
                 }
                 if(part.includes(":U")){
-                document.getElementById('remeditation_level').selectedIndex=4;        
+                document.getElementById('remeditation_level').selectedIndex=4;
                 }
-                }        
+                }
 
 
                 // report confidence
                 if(part.includes("RC:")){
                 if(part.includes(":X")){
-                document.getElementById('report_confidence').selectedIndex=0;        
+                document.getElementById('report_confidence').selectedIndex=0;
                 }
                 if(part.includes(":U")){
-                document.getElementById('report_confidence').selectedIndex=1;        
+                document.getElementById('report_confidence').selectedIndex=1;
                 }
                 if(part.includes(":R")){
-                document.getElementById('report_confidence').selectedIndex=2;        
+                document.getElementById('report_confidence').selectedIndex=2;
                 }
                 if(part.includes(":C")){
-                document.getElementById('report_confidence').selectedIndex=3;        
+                document.getElementById('report_confidence').selectedIndex=3;
                 }
-                }        
+                }
 
                 // confidentiality-requirement
                 if(part.includes("CR:")){
                 if(part.includes(":X")){
-                document.getElementById('confidentiality_requirement').selectedIndex=0;        
+                document.getElementById('confidentiality_requirement').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('confidentiality_requirement').selectedIndex=1;        
+                document.getElementById('confidentiality_requirement').selectedIndex=1;
                 }
                 if(part.includes(":M")){
-                document.getElementById('confidentiality_requirement').selectedIndex=2;        
+                document.getElementById('confidentiality_requirement').selectedIndex=2;
                 }
                 if(part.includes(":H")){
-                document.getElementById('confidentiality_requirement').selectedIndex=3;        
+                document.getElementById('confidentiality_requirement').selectedIndex=3;
                 }
-                }        
+                }
 
                 // integrity-requirement
                 if(part.includes("IR:")){
                 if(part.includes(":X")){
-                document.getElementById('integrity_requirement').selectedIndex=0;        
+                document.getElementById('integrity_requirement').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('integrity_requirement').selectedIndex=1;        
+                document.getElementById('integrity_requirement').selectedIndex=1;
                 }
                 if(part.includes(":M")){
-                document.getElementById('integrity_requirement').selectedIndex=2;        
+                document.getElementById('integrity_requirement').selectedIndex=2;
                 }
                 if(part.includes(":H")){
-                document.getElementById('integrity_requirement').selectedIndex=3;        
+                document.getElementById('integrity_requirement').selectedIndex=3;
                 }
-                }        
+                }
 
 
                 // integrity-requirement
                 if(part.includes("AR:")){
                 if(part.includes(":X")){
-                document.getElementById('availability_requirement').selectedIndex=0;        
+                document.getElementById('availability_requirement').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('availability_requirement').selectedIndex=1;        
+                document.getElementById('availability_requirement').selectedIndex=1;
                 }
                 if(part.includes(":M")){
-                document.getElementById('availability_requirement').selectedIndex=2;        
+                document.getElementById('availability_requirement').selectedIndex=2;
                 }
                 if(part.includes(":H")){
-                document.getElementById('availability_requirement').selectedIndex=3;        
+                document.getElementById('availability_requirement').selectedIndex=3;
                 }
-                }        
+                }
 
                 // modified-attack-vector
                 if(part.includes("MAV:")){
                 if(part.includes(":X")){
-                document.getElementById('mod_attack_vector').selectedIndex=0;        
+                document.getElementById('mod_attack_vector').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('mod_attack_vector').selectedIndex=1;        
+                document.getElementById('mod_attack_vector').selectedIndex=1;
                 }
                 if(part.includes(":A")){
-                document.getElementById('mod_attack_vector').selectedIndex=2;        
+                document.getElementById('mod_attack_vector').selectedIndex=2;
                 }
                 if(part.includes(":N")){
-                document.getElementById('mod_attack_vector').selectedIndex=3;        
+                document.getElementById('mod_attack_vector').selectedIndex=3;
                 }
                 if(part.includes(":P")){
-                document.getElementById('mod_attack_vector').selectedIndex=4;        
+                document.getElementById('mod_attack_vector').selectedIndex=4;
                 }
-                }        
+                }
 
                 // modified-attack-vector
                 if(part.includes("MAC:")){
                 if(part.includes(":X")){
-                document.getElementById('mod_attack_complexity').selectedIndex=0;        
+                document.getElementById('mod_attack_complexity').selectedIndex=0;
                 }
                 if(part.includes(":L")){
-                document.getElementById('mod_attack_complexity').selectedIndex=1;        
+                document.getElementById('mod_attack_complexity').selectedIndex=1;
                 }
                 if(part.includes(":H")){
-                document.getElementById('mod_attack_complexity').selectedIndex=2;        
+                document.getElementById('mod_attack_complexity').selectedIndex=2;
                 }
-                }        
+                }
 
                 // modified-privileges-Required
                 if(part.includes("MPR:")){
                 if(part.includes(":X")){
-                document.getElementById('mod_privileges_required').selectedIndex=0;        
+                document.getElementById('mod_privileges_required').selectedIndex=0;
                 }
                 if(part.includes(":N")){
-                document.getElementById('mod_privileges_required').selectedIndex=1;        
+                document.getElementById('mod_privileges_required').selectedIndex=1;
                 }
                 if(part.includes(":L")){
-                document.getElementById('mod_privileges_required').selectedIndex=2;        
+                document.getElementById('mod_privileges_required').selectedIndex=2;
                 }
                 if(part.includes(":H")){
-                document.getElementById('mod_privileges_required').selectedIndex=3;        
+                document.getElementById('mod_privileges_required').selectedIndex=3;
                 }
-                }        
+                }
 
                 // modified-user-interaction
                 if(part.includes("MUI:")){
                 if(part.includes(":X")){
-                document.getElementById('mod_user_interaction').selectedIndex=0;        
+                document.getElementById('mod_user_interaction').selectedIndex=0;
                 }
                 if(part.includes(":N")){
-                document.getElementById('mod_user_interaction').selectedIndex=1;        
+                document.getElementById('mod_user_interaction').selectedIndex=1;
                 }
                 if(part.includes(":R")){
-                document.getElementById('mod_user_interaction').selectedIndex=2;        
+                document.getElementById('mod_user_interaction').selectedIndex=2;
                 }
-                }        
+                }
 
 
                 // modified-scope
                 if(part.includes("MS:")){
                 if(part.includes(":X")){
-                document.getElementById('mod_scope').selectedIndex=0;        
+                document.getElementById('mod_scope').selectedIndex=0;
                 }
                 if(part.includes(":U")){
-                document.getElementById('mod_scope').selectedIndex=1;        
+                document.getElementById('mod_scope').selectedIndex=1;
                 }
                 if(part.includes(":C")){
-                document.getElementById('mod_scope').selectedIndex=2;        
+                document.getElementById('mod_scope').selectedIndex=2;
                 }
-                }        
+                }
 
                 // modified-confidentiality
                 if(part.includes("MC:")){
                 if(part.includes(":X")){
-                document.getElementById('mod_confidentiality').selectedIndex=0;        
+                document.getElementById('mod_confidentiality').selectedIndex=0;
                 }
                 if(part.includes(":N")){
-                document.getElementById('mod_confidentiality').selectedIndex=1;        
+                document.getElementById('mod_confidentiality').selectedIndex=1;
                 }
                 if(part.includes(":L")){
-                document.getElementById('mod_confidentiality').selectedIndex=2;        
+                document.getElementById('mod_confidentiality').selectedIndex=2;
                 }
                 if(part.includes(":H")){
-                document.getElementById('mod_confidentiality').selectedIndex=3;        
+                document.getElementById('mod_confidentiality').selectedIndex=3;
                 }
-                }        
+                }
 
                 // modified-integrity
                 if(part.includes("MI:")){
                 if(part.includes(":X")){
-                document.getElementById('mod_integrity').selectedIndex=0;        
+                document.getElementById('mod_integrity').selectedIndex=0;
                 }
                 if(part.includes(":N")){
-                document.getElementById('mod_integrity').selectedIndex=1;        
+                document.getElementById('mod_integrity').selectedIndex=1;
                 }
                 if(part.includes(":L")){
-                document.getElementById('mod_integrity').selectedIndex=2;        
+                document.getElementById('mod_integrity').selectedIndex=2;
                 }
                 if(part.includes(":H")){
-                document.getElementById('mod_integrity').selectedIndex=3;        
+                document.getElementById('mod_integrity').selectedIndex=3;
                 }
-                }        
+                }
 
 
                 // modified-availability
                 if(part.includes("MA:")){
                 if(part.includes(":X")){
-                document.getElementById('mod_availability').selectedIndex=0;        
+                document.getElementById('mod_availability').selectedIndex=0;
                 }
                 if(part.includes(":N")){
-                document.getElementById('mod_availability').selectedIndex=1;        
+                document.getElementById('mod_availability').selectedIndex=1;
                 }
                 if(part.includes(":L")){
-                document.getElementById('mod_availability').selectedIndex=2;        
+                document.getElementById('mod_availability').selectedIndex=2;
                 }
                 if(part.includes(":H")){
-                document.getElementById('mod_availability').selectedIndex=3;        
+                document.getElementById('mod_availability').selectedIndex=3;
                 }
-                }        
+                }
                 }}
 
-                var c = new CVSS("cvssboard", {
+                var c = new CVSS.js("cvssboard", {
                 onchange: function() {
                 document.getElementById('vs').value = c.get().vector;
                 updateDropdown(c.get().vector);
                 }
                 });
 
-                $("#vs").on('change keydown paste input', function(){               
-                updateDropdown(this.value);                
+                $("#vs").on('change keydown paste input', function(){
+                updateDropdown(this.value);
                 });
       %span{:class=>"input-group-btn"}
       .control-group
@@ -1192,8 +1192,8 @@
       .control-group
         %label{ :class => "control-label", :for => "likelihood_rationale" } Likelihood Rationale
         .controls
-          %textarea{ :rows => '3', :class => 'input-xxlarge allowMarkupShortcut', :id => 'likelihood_rationale', :name => 'likelihood_rationale'}       
-             
+          %textarea{ :rows => '3', :class => 'input-xxlarge allowMarkupShortcut', :id => 'likelihood_rationale', :name => 'likelihood_rationale'}
+
     - else
       .control-group
         %label{ :class => "control-label", :for => "effort" } Remediation Effort
@@ -1346,8 +1346,8 @@
           %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :name => 'presentation_rem_points'}
             - if @finding
               - if @finding.presentation_rem_points
-                #{meta_markup(@finding.presentation_rem_points)}      
-    
+                #{meta_markup(@finding.presentation_rem_points)}
+
     - id_r = @report ? "/report/#{@report.id}/findings" : "/master/findings"
     %input{:type => 'submit', :value => 'Save'}
     %a{ :href => "#{id_r}"}

--- a/views/create_finding.haml
+++ b/views/create_finding.haml
@@ -324,7 +324,7 @@
         .controls
           %select{ :name => "av", :id => "av" }
             %option Local
-            %option Local Network
+            %option Adjacent Network
             %option Network
       .control-group
         %label.control-label{ :for => "ac" } Access Complexity

--- a/views/findings_edit.haml
+++ b/views/findings_edit.haml
@@ -1,5 +1,5 @@
-%link{:href => "/css/bootstrap-suggest.css", :rel => "stylesheet"}/
-%script{:src => "/js/bootstrap-suggest.js"}
+%link{ :href => "/css/bootstrap-suggest.css", :rel => "stylesheet" }/
+%script{ :src => "/js/bootstrap-suggest.js" }
 
 .span10
   %br
@@ -854,10 +854,12 @@
         } else {
           var value;
 
-          if (element.value.indexOf("-") < 0) {
+          if (element.value.toUpperCase() == "LOW-MEDIUM") {
+            value = "LM";
+          } else if (element.value.toUpperCase() == "MEDIUM-HIGH") {
+            value = "MH";
+          } else  {
             value = element.value[0];
-          } else {
-            value = element.value.split("-")[0][0] + element.value.split("-")[1][0];
           }
 
           vectorString += "/" + element.getAttribute("data-cvss-tag") + ":" + value;

--- a/views/findings_edit.haml
+++ b/views/findings_edit.haml
@@ -403,11 +403,11 @@
                 }
                 }
                 }}
-                var c = new CVSS.js("cvssboard", {
+                var cvssjs = new CVSS.js("cvssboard", {
                 onchange: function() {
                 window.location.hash = cvssjs.get().vector;
                 document.getElementById('vs').value = cvssjs.get().vector;
-                updateDropdown(cvssjs.get().vector);ç
+                updateDropdown(cvssjs.get().vector);
                 }
                 });
 

--- a/views/findings_edit.haml
+++ b/views/findings_edit.haml
@@ -6,11 +6,11 @@
   %h2 #{@finding.title}
   %br
   %br
-  %form{ :class => "form-horizontal", :method => 'post', :enctype => 'application/x-www-form-urlencoded'}
+  %form.form-horizontal{ :method => "post", :enctype => "application/x-www-form-urlencoded" }
     .control-group
       %label.control-label{ :for => "title" } Title
       .controls
-        %input{ :type => 'text', :name => 'title', :value => "#{@finding.title}"}
+        %input{ :type => "text", :name => "title", :value => "#{@finding.title}" }
     -if !@master
       %br
       .control-group
@@ -28,32 +28,32 @@
         %label.control-label{ :for => "approved" } Approved
         .controls
           -if @finding.approved
-            %input{ :type=>"checkbox", :name => 'approved', :checked=>"checked"}
+            %input{ :type=>"checkbox", :name => "approved", :checked=>"checked" }
           - else
-            %input{ :type=>"checkbox", :name => 'approved'}
+            %input{ :type=>"checkbox", :name => "approved" }
       - if @vulnmap
         .control-group
           %label.control-label{ :for => "existingvulnmaps" } Vuln IDs mapped to this finding
           .controls
             .table
-              %table{ :style => 'width: 220px'}
+              %table{ :style => "width: 220px" }
                 - @vulnmaps.each do |vuln|
                   - if vuln.msf_ref
                     %tr
                       %td
                         #{vuln.msf_ref}
-                      %td{ :align => "right"}
-                        %a{ :class => "btn btn-danger btn-sm", :href => "/mapping/#{@finding.id}/vulnmap/#{vuln.id}/delete"}
-                          %i{:class => 'icon-remove icon-white icon-sm', :value => "#{vuln.msf_ref}", :type => "submit", :title => 'Delete'}
+                      %td{ :align => "right" }
+                        %a.btn.btn-danger.btn-sm{ :href => "/mapping/#{@finding.id}/vulnmap/#{vuln.id}/delete" }
+                          %i.icon-remove.icon-white.icon-sm{ :value => "#{vuln.msf_ref}", :type => "submit", :title => "Delete" }
         .control-group
           %label.control-label{ :for => "msf_ref" }
-            %a{:href=> '#mymodal', "data-toggle"=>'modal', :class=>'btn btn-info'}
+            %a.btn.btn-info{ :href => "#mymodal", "data-toggle" => "modal" }
               Add new Vuln ID mapping
-          .modal{:id=>'mymodal', :class=>'modal hide fade', :tabindex=>'-1', :role=>'dialog', "aria-labelledby"=>'modal-label', "aria-hidden"=>'true'}
+          .modal.modal.hide.fade#mymodal{ :tabindex => "-1", :role => "dialog", "aria-labelledby" => "modal-label", "aria-hidden" => "true"}
             .modal-header
-              %button{:type=>'button', :class=>'close', "data-dismiss"=>"modal", "aria-hidden"=>"true"}
+              %button.close{ :type => "button", "data-dismiss" => "modal", "aria-hidden" => "true" }
                 x
-              %h3{:id=>"modal-label"}
+              %h3#modal-label
                 Vulnerability Importing
             .modal-body
               %p
@@ -61,19 +61,19 @@
               %p
                 When importing vulnerabilities from Metasploit, Serpico will split these reference codes by comma. Whatever is placed in the Vuln ID mapping field will be checked for a string comparison upon import. This allows Serpico to support any type of vendor/tool that Metasploit supports.
               %h4 Big fat Warning
-              %p{:class=>"text-error"}
+              %p.text-error
                 Metasploit doesn't do the best job at parsing these reference codes. Use CVEs over vendor specific IDs whenever possible. Burp is not support via this method. Instead, use the legacy Burp XML importer.
               %br
                 %h4 Supported reference codes:
                 .table
-                  %table{:width => "70%"}
-                    %thead{:width => "20%"}
+                  %table{ :width => "70%" }
+                    %thead{ :width => "20%" }
                       %tr
                         %td
                           %b Type
                         %td
                           %b Format to use
-                    %tbody{:width => "50%"}
+                    %tbody{ :width => "50%" }
                       %tr
                         %td
                           CVE
@@ -85,456 +85,242 @@
                         %td
                           NSS-1234
           .controls
-            %input{ :type => 'text', :name => 'msf_ref'}
+            %input{ :type => "text", :name => "msf_ref" }
       - if @nessusmap
         .control-group
           %label.control-label{ :for => "existingnessusmaps" } Nessus IDs Mapped to this finding
           .controls
             .table
-              %table{ :style => 'width: 220px'}
+              %table{ :style => "width: 220px" }
                 %tbody
                 - @nessus.each do |item|
                   - if item.pluginid
                     %tr
                       %td
                         #{item.pluginid}
-                      %td{ :align => "right"}
-                        %a{ :class => "btn btn-danger btn-xs", :href => "/mapping/#{@finding.id}/nessus/#{item.pluginid}/delete"}
-                          %i{:class => 'icon-remove icon-white', :value => "#{item.pluginid}", :type => "submit", :title => 'Delete'}
+                      %td{ :align => "right" }
+                        %a.btn.btn-danger.btn-xs{ :href => "/mapping/#{@finding.id}/nessus/#{item.pluginid}/delete" }
+                          %i.icon-remove.icon-white{ :value => "#{item.pluginid}", :type => "submit", :title => "Delete" }
         .control-group
           %label.control-label{ :for => "nessus_pluginid" } Add new nessus ID mapping
           .controls
-            %input{ :type => 'text', :name => 'nessus_pluginid'}
+            %input{ :type => "text", :name => "nessus_pluginid" }
       - if @burpmap
         .control-group
           %label.control-label{ :for => "existingburpmaps" } Burp IDs Mapped to this finding
           .controls
             .table
-              %table{ :style => 'width: 220px'}
+              %table{ :style => "width: 220px" }
                 %tbody
                 - @burp.each do |item|
                   - if item.pluginid
                     %tr
                       %td
                         #{item.pluginid}
-                      %td{ :align => "right"}
-                        %a{ :class => "btn btn-danger btn-xs", :href => "/mapping/#{@finding.id}/burp/#{item.pluginid}/delete"}
-                          %i{:class => 'icon-remove icon-white', :value => "#{item.pluginid}", :type => "submit", :title => 'Delete'}
+                      %td{ :align => "right" }
+                        %a.btn.btn-danger.btn-xs{ :href => "/mapping/#{@finding.id}/burp/#{item.pluginid}/delete" }
+                          %i.icon-remove.icon-white{ :value => "#{item.pluginid}", :type => "submit", :title => "Delete" }
         .control-group
           %label.control-label{ :for => "burp_pluginid" }
-            %a{:href=> '#burpmodal', "data-toggle"=>'modal'}
+            %a{ :href => "#burpmodal", "data-toggle" => "modal" }
               Add new Burp ID mapping
-          .modal{:id=>'burpmodal', :class=>'modal hide fade', :tabindex=>'-1', :role=>'dialog', "aria-labelledby"=>'modal-label', "aria-hidden"=>'true'}
+          .modal.modal.hide.fade#burpmodal{ :tabindex => "-1", :role => "dialog", "aria-labelledby" => "modal-label", "aria-hidden" => "true" }
             .modal-header
-              %button{:type=>'button', :class=>'close', "data-dismiss"=>"modal", "aria-hidden"=>"true"}
+              %button.close{ :type => "button", "data-dismiss" => "modal", "aria-hidden" => "true" }
                 x
-              %h3{:id=>"modal-label"}
+              %h3#modal-label
                 Mapping Burp findings
             .modal-body
               You can use the following link to help map burp's ids to your findings:
               %br
               %br
-              %a{:href=> "http://portswigger.net/burp/help/scanner_issuetypes.html", :target => "_blank"} http://portswigger.net/burp/help/scanner_issuetypes.html
+              %a{ :href => "http://portswigger.net/burp/help/scanner_issuetypes.html", :target => "_blank" } http://portswigger.net/burp/help/scanner_issuetypes.html
               %br
           .controls
-            %input{ :type => 'text', :name => 'burp_pluginid'}
+            %input{ :type => "text", :name => "burp_pluginid" }
     - if @dread
       .control-group
         %label.control-label{ :for => "damage" } Damage
         .controls
-          %input{ :type => 'number', :min => '1', :max => '10', :name => 'damage', :value => "#{@finding.damage}", :required => true}
+          %input{ :type => "number", :min => "1", :max => "10", :name => "damage", :value => "#{@finding.damage}", :required => true }
       .control-group
         %label.control-label{ :for => "reproducability" } Reproducibility
         .controls
-          %input{ :type => 'number', :min => '1', :max => '10', :name => 'reproducability', :value => "#{@finding.reproducability}", :required => true}
+          %input{ :type => "number", :min => "1", :max => "10", :name => "reproducability", :value => "#{@finding.reproducability}", :required => true }
       .control-group
         %label.control-label{ :for => "exploitability" } Exploitability
         .controls
-          %input{ :type => 'number', :min => '1', :max => '10', :name => 'exploitability', :value => "#{@finding.exploitability}", :required => true}
+          %input{ :type => "number", :min => "1", :max => "10", :name => "exploitability", :value => "#{@finding.exploitability}", :required => true }
       .control-group
         %label.control-label{ :for => "affected_users" } Affected Users
         .controls
-          %input{ :type => 'number', :min => '1', :max => '10', :name => 'affected_users', :value => "#{@finding.affected_users}", :required => true}
+          %input{ :type => "number", :min => "1", :max => "10", :name => "affected_users", :value => "#{@finding.affected_users}", :required => true }
       .control-group
         %label.control-label{ :for => "discoverability" } Discoverability
         .controls
-          %input{ :type => 'number', :min => '1', :max => '10', :name => 'discoverability', :value => "#{@finding.discoverability}", :required => true}
+          %input{ :type => "number", :min => "1", :max => "10", :name => "discoverability", :value => "#{@finding.discoverability}", :required => true }
     - elsif @cvss
       .control-group
         %label.control-label{ :for => "attack_vector" }
-          %a{:href=> '#mymodal', "data-toggle"=>'modal', :class=>'btn btn-info'}
+          %a.btn.btn-info{ :href=> "#mymodal", "data-toggle" => "modal" }
             CVSS Vector String
         .controls
-          %input{:type => "text", :class=>"form-control", :placeholder=>"CVSS Vector String", :id=>"vs", :style=>"width:35em"}
-        .modal{:id=>'mymodal', :class=>'modal hide fade', :tabindex=>'-1', :role=>'dialog', "aria-labelledby"=>'modal-label', "aria-hidden"=>'true'}
+          %input.form-control#vs{ :type => "text", :placeholder => "CVSS Vector String", :style => "width:35em" }
+        .modal.modal.hide.fade#mymodal{ :tabindex => "-1", :role => "dialog", "aria-labelledby" => "modal-label", "aria-hidden" => "true" }
           .modal-header
-            %button{:type=>'button', :class=>'close', "data-dismiss"=>"modal", "aria-hidden"=>"true"}
+            %button.close{ :type => "button", "data-dismiss" => "modal", "aria-hidden" => "true" }
               x
-            %h3{:id=>"modal-label"}
+            %h3#modal-label
               CVSS Vector String
           .modal-body
-            %link{ :rel=>"stylesheet", :type=>"text/css", :media=>"all", :href=>"/css/cvss.css"}
-            %script{ :src => "/js/cvss.js"}
-            %div{ :id=>"cvssboard"}
-              %script
-                function updateDropdown(score){
-                var vector = score.trim().split("/");
-                for(var i in vector){
-                var part = vector[i];
+            %link{ :rel => "stylesheet", :type => "text/css", :media => "all", :href => "/css/cvss.css" }
+            %script{ :src => "/js/cvsscalc20.js" }
+            %script{ :src => "/js/cvss.js" }
+            %div#cvssboard
+      %span.input-group-btn
+      .control-group.cvss2
+        %label.control-label{ :for => "baseScore" } Base Score
+        .controls
+          #baseScore.cvssjs
+            .results
+              %span.score
+              %span.severity
+      .control-group.cvss2
+        %label.control-label{ :for => "temporalScore" } Temporal Score
+        .controls
+          #temporalScore.cvssjs
+            .results
+              %span.score
+              %span.severity
+      .control-group.cvss2
+        %label.control-label{ :for => "environmentalScore" } Environmental Score
+        .controls
+          #environmentalScore.cvssjs
+            .results
+              %span.score
+              %span.severity
 
-                if (part.length > 0){
-                part = part.toUpperCase();
-                }
-                // AV
-                if(part.includes("AV:")){
-                if(part.includes(":L")){
-                document.getElementById('av').selectedIndex=0;
-                }
-                if(part.includes(":A")){
-                document.getElementById('av').selectedIndex=1;
-                }
-                if(part.includes(":N")){
-                document.getElementById('av').selectedIndex=2;
-                }
-                }
-
-                // AC
-                if(part.includes("AC:")){
-                if(part.includes(":H")){
-                document.getElementById('ac').selectedIndex=0;
-                }
-                if(part.includes(":M")){
-                document.getElementById('ac').selectedIndex=1;
-                }
-                if(part.includes(":L")){
-                document.getElementById('ac').selectedIndex=2;
-                }
-                }
-
-                // AU
-                if(part.includes("AU:")){
-                if(part.includes(":M")){
-                document.getElementById('au').selectedIndex=0;
-                }
-                if(part.includes(":S")){
-                document.getElementById('au').selectedIndex=1;
-                }
-                if(part.includes(":N")){
-                document.getElementById('au').selectedIndex=2;
-                }
-                }
-
-                // C
-                if(part.includes("C:")){
-                if(part.includes(":N")){
-                document.getElementById('c').selectedIndex=0;
-                }
-                if(part.includes(":P")){
-                document.getElementById('c').selectedIndex=1;
-                }
-                if(part.includes(":C")){
-                document.getElementById('c').selectedIndex=2;
-                }
-                }
-
-                // I
-                if(part.includes("I:")){
-                if(part.includes(":N")){
-                document.getElementById('i').selectedIndex=0;
-                }
-                if(part.includes(":P")){
-                document.getElementById('i').selectedIndex=1;
-                }
-                if(part.includes(":C")){
-                document.getElementById('i').selectedIndex=2;
-                }
-                }
-
-                // A
-                if(part.includes("A:")){
-                if(part.includes(":N")){
-                document.getElementById('a').selectedIndex=0;
-                }
-                if(part.includes(":P")){
-                document.getElementById('a').selectedIndex=1;
-                }
-                if(part.includes(":C")){
-                document.getElementById('a').selectedIndex=2;
-                }
-                }
-
-                // E
-                if(part.includes("E:")){
-                if(part.includes(":ND")){
-                document.getElementById('e').selectedIndex=0;
-                }
-                if(part.includes(":U")){
-                document.getElementById('e').selectedIndex=1;
-                }
-                if(part.includes(":POC")){
-                document.getElementById('e').selectedIndex=2;
-                }
-                if(part.includes(":F")){
-                document.getElementById('e').selectedIndex=3;
-                }
-                if(part.includes(":H")){
-                document.getElementById('e').selectedIndex=4;
-                }
-                }
-
-                // RL
-                if(part.includes("RL:")){
-                if(part.includes(":ND")){
-                document.getElementById('rl').selectedIndex=0;
-                }
-                if(part.includes(":OF")){
-                document.getElementById('rl').selectedIndex=1;
-                }
-                if(part.includes(":TF")){
-                document.getElementById('rl').selectedIndex=2;
-                }
-                if(part.includes(":W")){
-                document.getElementById('rl').selectedIndex=3;
-                }
-                if(part.includes(":U")){
-                document.getElementById('rl').selectedIndex=4;
-                }
-                }
-
-                // RC
-                if(part.includes("RC:")){
-                if(part.includes(":ND")){
-                document.getElementById('rc').selectedIndex=0;
-                }
-                if(part.includes(":UC")){
-                document.getElementById('rc').selectedIndex=1;
-                }
-                if(part.includes(":UR")){
-                document.getElementById('rc').selectedIndex=2;
-                }
-                if(part.includes(":C")){
-                document.getElementById('rc').selectedIndex=3;
-                }
-                }
-
-                // CDP
-                if(part.includes("CDP:")){
-                if(part.includes(":ND")){
-                document.getElementById('cdp').selectedIndex=0;
-                }
-                if(part.includes(":N")){
-                document.getElementById('cdp').selectedIndex=1;
-                }
-                if(part.includes(":LM")){
-                document.getElementById('cdp').selectedIndex=2;
-                }
-                if(part.includes(":MH")){
-                document.getElementById('cdp').selectedIndex=3;
-                }
-                if(part.includes(":H")){
-                document.getElementById('cdp').selectedIndex=4;
-                }
-                }
-
-                // TD
-                if(part.includes("TD:")){
-                if(part.includes(":ND")){
-                document.getElementById('td').selectedIndex=0;
-                }
-                if(part.includes(":N")){
-                document.getElementById('td').selectedIndex=1;
-                }
-                if(part.includes(":L")){
-                document.getElementById('td').selectedIndex=2;
-                }
-                if(part.includes(":M")){
-                document.getElementById('td').selectedIndex=3;
-                }
-                if(part.includes(":H")){
-                document.getElementById('td').selectedIndex=4;
-                }
-                }
-
-                // CD
-                if(part.includes("CR:")){
-                if(part.includes(":ND")){
-                document.getElementById('cd').selectedIndex=0;
-                }
-                if(part.includes(":L")){
-                document.getElementById('cd').selectedIndex=1;
-                }
-                if(part.includes(":M")){
-                document.getElementById('cd').selectedIndex=2;
-                }
-                if(part.includes(":H")){
-                document.getElementById('cd').selectedIndex=3;
-                }
-                }
-
-                // IR
-                if(part.includes("IR:")){
-                if(part.includes(":ND")){
-                document.getElementById('ir').selectedIndex=0;
-                }
-                if(part.includes(":L")){
-                document.getElementById('ir').selectedIndex=1;
-                }
-                if(part.includes(":M")){
-                document.getElementById('ir').selectedIndex=2;
-                }
-                if(part.includes(":H")){
-                document.getElementById('ir').selectedIndex=3;
-                }
-                }
-
-                // AR
-                if(part.includes("AR:")){
-                if(part.includes(":ND")){
-                document.getElementById('ar').selectedIndex=0;
-                }
-                if(part.includes(":L")){
-                document.getElementById('ar').selectedIndex=1;
-                }
-                if(part.includes(":M")){
-                document.getElementById('ar').selectedIndex=2;
-                }
-                if(part.includes(":H")){
-                document.getElementById('ar').selectedIndex=3;
-                }
-                }
-                }}
-                var cvssjs = new CVSS.js("cvssboard", {
-                onchange: function() {
-                window.location.hash = cvssjs.get().vector;
-                document.getElementById('vs').value = cvssjs.get().vector;
-                updateDropdown(cvssjs.get().vector);
-                }
-                });
-
-                $("#vs").on('change keydown paste input', function(){
-                updateDropdown(this.value);
-                });
-      .control-group
+      .control-group.cvss2
         %label.control-label{ :for => "av" } Access Vector
         .controls
-          %select{ :name => "av", :id => "av" }
+          %select#av{ :name => "av", "data-cvss-tag" => "AV" }
             - options.av.each do |av|
               - if av == @finding.av
                 %option{ :selected => "selected" } #{av}
               - else
                 %option #{av}
-      .control-group
+      .control-group.cvss2
         %label.control-label{ :for => "ac" } Access Complexity
         .controls
-          %select{ :name => "ac", :id => "ac" }
+          %select#ac{ :name => "ac", "data-cvss-tag" => "AC" }
             - options.ac.each do |ac|
               - if ac == @finding.ac
                 %option{ :selected => "selected" } #{ac}
               - else
                 %option #{ac}
-      .control-group
+      .control-group.cvss2
         %label.control-label{ :for => "au" } Authentication
         .controls
-          %select{ :name => "au", :id => "au" }
+          %select#au{ :name => "au", "data-cvss-tag" => "AU" }
             - options.au.each do |au|
               - if au == @finding.au
                 %option{ :selected => "selected" } #{au}
               - else
                 %option #{au}
-      .control-group
+      .control-group.cvss2
         %label.control-label{ :for => "c" } Confidentiality Impact
         .controls
-          %select{ :name => "c", :id => "c" }
+          %select#c{ :name => "c", "data-cvss-tag" => "C" }
             - options.c.each do |c|
               - if c == @finding.c
                 %option{ :selected => "selected" } #{c}
               - else
                 %option #{c}
-      .control-group
+      .control-group.cvss2
         %label.control-label{ :for => "i" } Integrity Impact
         .controls
-          %select{ :name => "i", :id => "i" }
+          %select#i{ :name => "i", "data-cvss-tag" => "I" }
             - options.i.each do |i|
               - if i == @finding.i
                 %option{ :selected => "selected" } #{i}
               - else
                 %option #{i}
-      .control-group
+      .control-group.cvss2
         %label.control-label{ :for => "a" } Availability Impact
         .controls
-          %select{ :name => "a", :id => "a" }
+          %select#a{ :name => "a", "data-cvss-tag" => "A" }
             - options.a.each do |a|
               - if a == @finding.a
                 %option{ :selected => "selected" } #{a}
               - else
                 %option #{a}
-      .control-group
+      .control-group.cvss2
         %label.control-label{ :for => "e" } Exploitability
         .controls
-          %select{ :name => "e", :id => "e" }
+          %select#e{ :name => "e", "data-cvss-tag" => "E" }
             - options.e.each do |e|
               - if e == @finding.e
                 %option{ :selected => "selected" } #{e}
               - else
                 %option #{e}
-      .control-group
+      .control-group.cvss2
         %label.control-label{ :for => "rl" } Remediation Level
         .controls
-          %select{ :name => "rl", :id => "rl" }
+          %select#rl{ :name => "rl", "data-cvss-tag" => "RL" }
             - options.rl.each do |rl|
               - if rl == @finding.rl
                 %option{ :selected => "selected" } #{rl}
               - else
                 %option #{rl}
-      .control-group
+      .control-group.cvss2
         %label.control-label{ :for => "rc" } Report Confidence
         .controls
-          %select{ :name => "rc", :id => "rc" }
+          %select#rc{ :name => "rc", "data-cvss-tag" => "RC" }
             - options.rc.each do |rc|
               - if rc == @finding.rc
                 %option{ :selected => "selected" } #{rc}
               - else
                 %option #{rc}
-      .control-group
+      .control-group.cvss2
         %label.control-label{ :for => "cdp" } Collateral Damage Potential
         .controls
-          %select{ :name => "cdp", :id => "cdp" }
+          %select#cdp{ :name => "cdp", "data-cvss-tag" => "CDP" }
             - options.cdp.each do |cdp|
               - if cdp == @finding.cdp
                 %option{ :selected => "selected" } #{cdp}
               - else
                 %option #{cdp}
-      .control-group
+      .control-group.cvss2
         %label.control-label{ :for => "td" } Target Distribution
         .controls
-          %select{ :name => "td", :id => "td" }
+          %select#td{ :name => "td", "data-cvss-tag" => "TD" }
             - options.td.each do |td|
               - if td == @finding.td
                 %option{ :selected => "selected" } #{td}
               - else
                 %option #{td}
-      .control-group
+      .control-group.cvss2
         %label.control-label{ :for => "cr" } Confidentiality Requirement
         .controls
-          %select{ :name => "cr", :id => "cr" }
+          %select#cr{ :name => "cr", "data-cvss-tag" => "CR" }
             - options.cr.each do |cr|
               - if cr == @finding.cr
                 %option{ :selected => "selected" } #{cr}
               - else
                 %option #{cr}
-      .control-group
+      .control-group.cvss2
         %label.control-label{ :for => "ir" } Integrity Requirement
         .controls
-          %select{ :name => "ir", :id => "ir" }
+          %select#ir{ :name => "ir", "data-cvss-tag" => "IR" }
             - options.ir.each do |ir|
               - if ir == @finding.ir
                 %option{ :selected => "selected" } #{ir}
               - else
                 %option #{ir}
-      .control-group
+      .control-group.cvss2
         %label.control-label{ :for => "ar" } Availability Requirement
         .controls
-          %select{ :name => "ar", :id => "ar" }
+          %select#ar{ :name => "ar", "data-cvss-tag" => "AR" }
             - options.ar.each do |ar|
               - if ar == @finding.ar
                 %option{ :selected => "selected" } #{ar}
@@ -543,7 +329,7 @@
     - elsif @cvssv3
       .control-group.cvss3
         %label.control-label{ :for => "attack_vector" }
-          %a.btn.btn-info{:href=> "#mymodal", "data-toggle"=>'modal', :class=>'btn btn-info'}
+          %a.btn.btn-info{ :href => "#mymodal", "data-toggle" => "modal" }
             CVSS Vector String
         .controls
           %input.form-control#vs{ :type => "text", :placeholder=>"CVSS Vector String", :style=>"width:35em" }
@@ -555,26 +341,26 @@
               CVSS Vector String
           .modal-body
             %link{ :rel => "stylesheet", :type => "text/css", :media => "all", :href => "/css/cvss.css" }
-            %script{:src => "/js/cvsscalc30.js"}
+            %script{ :src => "/js/cvsscalc30.js" }
             %script{ :src => "/js/cvss3.js"}
             %div#cvssboard
       %span.input-group-btn
       .control-group.cvss3
-        %label.control-label{ :for => "attack_vector" } Base Score
+        %label.control-label{ :for => "baseScore" } Base Score
         .controls
           #baseScore.cvssjs
             .results
               %span.score
               %span.severity
       .control-group.cvss3
-        %label.control-label{ :for => "attack_vector" } Temporal Score
+        %label.control-label{ :for => "temporalScore" } Temporal Score
         .controls
           #temporalScore.cvssjs
             .results
               %span.score
               %span.severity
       .control-group.cvss3
-        %label.control-label{ :for => "attack_vector" } Environmental Score
+        %label.control-label{ :for => "environmentalScore" } Environmental Score
         .controls
           #environmentalScore.cvssjs
             .results
@@ -584,7 +370,7 @@
       .control-group.cvss3
         %label.control-label{ :for => "attack_vector" } Attack Vector
         .controls
-          %select{ :name => "attack_vector", :id => "attack_vector", "data-cvss-tag" => "AV"  }
+          %select#attack_vector{ :name => "attack_vector", "data-cvss-tag" => "AV"  }
             - options.attack_vector.each do |attack_vector|
               - if attack_vector == @finding.attack_vector
                 %option{ :selected => "selected" } #{attack_vector}
@@ -805,7 +591,7 @@
       .control-group
         %label.control-label{ :for => "severity_rationale" } Severity Rationale
         .controls
-          %textarea{ :rows => '3', :class => 'input-xxlarge allowMarkupShortcut', :id => 'severity_rationale', :name => 'severity_rationale'}
+          %textarea.input-xxlarge.allowMarkupShortcut#severity_rationale{ :rows => "3", :name => "severity_rationale" }
             - if @finding
               - if @finding.severity_rationale
                 #{meta_markup(@finding.severity_rationale)}
@@ -821,7 +607,7 @@
       .control-group
         %label.control-label{ :for => "likelihood_rationale" } Likelihood Rationale
         .controls
-          %textarea{ :rows => '3', :class => 'input-xxlarge allowMarkupShortcut', :id => 'likelihood_rationale', :name => 'likelihood_rationale'}
+          %textarea.input-xxlarge.allowMarkupShortcut#likelihood_rationale{ :rows => "3", :name => "likelihood_rationale" }
             - if @finding
               - if @finding.likelihood_rationale
                 #{meta_markup(@finding.likelihood_rationale)}
@@ -859,18 +645,18 @@
               %option #{type}
     .control-group
       %label.control-label{ :for => "overview" }
-        %a{:href=> '#modaloverview', "data-toggle"=>'modal', :class=>'btn btn-info'}
+        %a.btn.btn-info{ :href=> "#modaloverview", "data-toggle" => "modal" }
           Overview
-      .modal{:id=>'modaloverview', :class=>'modal hide fade', :tabindex=>'-1', :role=>'dialog', "aria-labelledby"=>'modal-label', "aria-hidden"=>'true'}
+      .modal.modal.hide.fade#modaloverview{ :tabindex => "-1", :role => "dialog", "aria-labelledby" => "modal-label", "aria-hidden" => "true"}
         .modal-header
-          %button{:type=>'button', :class=>'close', "data-dismiss"=>"modal", "aria-hidden"=>"true"}
+          %button.close{ :type => "button", "data-dismiss" => "modal", "aria-hidden" => "true" }
             x
-          %h3{:id=>"modal-label"}
+          %h3#modal-label
             Meta Markup
         .modal-body
           %p
             There are four markup sets you can use in the Overview and the Remediation summary. This text is converted inside of Microsoft Word.
-            %p{:class=>"text-error"}
+            %p.text-error
               YOU MUST CLOSE ALL TAGS. OTHERWISE YOU CAN DESTROY ALL TEXT FORMATTING. SEE EXAMPLES BELOW.
             %b
               Review the finding "TEST - Markup Tester" for a clear example. As always, press preview to see the finding in Word.
@@ -930,14 +716,14 @@
             %code
               [[[ code, code goes here ]]]
       .controls
-        %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :id => 'overview', :name => 'overview'}
+        %textarea.input-xxlarge.allowMarkupShortcut#overview{ :rows => "10", :name => "overview" }
           - if @finding
             - if @finding.overview
               #{meta_markup(@finding.overview)}
     .control-group
       %label.control-label{ :for => "pocu" } Proof of Concept
       .controls
-        %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :name => 'poc', :id => "pocu"}
+        %textarea.input-xxlarge.allowMarkupShortcut#pocu{ :rows => "10", :name => "poc" }
           - if @finding
             - if @finding.poc
               #{meta_markup(@finding.poc)}
@@ -968,61 +754,61 @@
       .control-group
         %label.control-label{ :for => "affected_hosts" } Affected Hosts/URLs
         .controls
-          %textarea{ :rows => '3', :class => 'input-xxlarge allowMarkupShortcut', :name => 'affected_hosts'}
+          %textarea.input-xxlarge.allowMarkupShortcut{ :rows => "3", :name => "affected_hosts" }
             - if @finding
               - if @finding.affected_hosts
                 #{meta_markup(@finding.affected_hosts)}
     .control-group
       %label.control-label{ :for => "remediation" } Remediation
       .controls
-        %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :name => 'remediation'}
+        %textarea.input-xxlarge.allowMarkupShortcut{ :rows => "10", :name => "remediation" }
           - if @finding
             - if @finding.remediation
               #{meta_markup(@finding.remediation)}
     .control-group
       %label.control-label{ :for => "references" } References (One Per Line)
       .controls
-        %textarea{ :rows => '5', :class => 'input-xxlarge allowMarkupShortcut', :name => 'references'}
+        %textarea.input-xxlarge.allowMarkupShortcut{ :rows => "5", :name => "references" }
           - if @finding
             - if @finding.references
               #{meta_markup(@finding.references)}
     - if !@master
       .control-group
         %label.control-label{ :for => "notes" } Notes Data
-        %i{:class=>"icon-chevron-down", "data-toggle"=>"collapse", "data-target"=>"#info_2", :id=>"actionButton"}
-        .info{ :id => "info_2", :class => "collapse out" }
+        %i.icon-chevron-down#actionButton{ "data-toggle" => "collapse", "data-target" => "#info_2" }
+        .info.collapse.out#info_2
           %label
             Notes
           .controls
-          %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :name => 'notes'}
+          %textarea.input-xxlarge.allowMarkupShortcut{ :rows => "10", :name => "notes" }
             - if @finding
               - if @finding.notes
                 #{meta_markup(@finding.notes)}
     - if !@master
       .control-group
         %label.control-label{ :for => "preso" } Presentation Data
-        %i{:class=>"icon-chevron-down", "data-toggle"=>"collapse", "data-target"=>"#info_1", :id=>"actionButton"}
-        .info{ :id => "info_1", :class => "collapse out" }
+        %i.icon-chevron-down#actionButton{ "data-toggle" => "collapse", "data-target" => "#info_1" }
+        .info.collapse.out#info_1
           %label
             Presentation Points (One Per Line)
           .controls
-          %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :name => 'presentation_points'}
+          %textarea.input-xxlarge.allowMarkupShortcut{ :rows => "10", :name => "presentation_points" }
             - if @finding
               - if @finding.presentation_points
                 #{meta_markup(@finding.presentation_points)}
           %label
             Presentation Remediation Points (One Per Line)
           .controls
-          %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :name => 'presentation_rem_points'}
+          %textarea.input-xxlarge.allowMarkupShortcut{ :rows => "10", :name => "presentation_rem_points" }
             - if @finding
               - if @finding.presentation_rem_points
                 #{meta_markup(@finding.presentation_rem_points)}
 
 
     - id_r = @report ? "/report/#{@report.id}/findings" : "/master/findings"
-    %input{:type => 'submit', :value => 'Save'}
-    %a{ :href => "#{id_r}"}
-      %input{ :type => "button", :value => 'Cancel'}
+    %input{ :type => "submit", :value => "Save" }
+    %a{ :href => "#{id_r}" }
+      %input{ :type => "button", :value => "Cancel" }
 
 :javascript
   function confirmDelete(evt) {
@@ -1036,27 +822,45 @@
     deleteElements[index].addEventListener('click', confirmDelete, false);
   }
 
+-if @cvss
+  :javascript
+    cvss_prefix = "CVSS:2.0";
+
 -if @cvssv3
+  :javascript
+    cvss_prefix = "CVSS:3.0";
+
+-if @cvss or @cvssv3
   :css
-    .cvss3 .cvssjs .results {
+    .cvss3 .cvssjs .results,
+    .cvss2 .cvssjs .results {
       padding: 0px;
     }
 
   :javascript
     var cvssjs;
+    var cvss_prefix;
 
     function updateCVSS() {
       updateCVSSSummary(true);
     }
 
     function updateCVSSSummary(updateCVSSJS) {
-      var vectorString = "CVSS:3.0";
+      var vectorString = cvss_prefix;
 
       $("select[data-cvss-tag]").each(function (index, element) {
         if (element.value.toLowerCase() == "not defined") {
           vectorString += "/" + element.getAttribute("data-cvss-tag") + ":X";
         } else {
-          vectorString += "/" + element.getAttribute("data-cvss-tag") + ":" + element.value[0];
+          var value;
+
+          if (element.value.indexOf("-") < 0) {
+            value = element.value[0];
+          } else {
+            value = element.value.split("-")[0][0] + element.value.split("-")[1][0];
+          }
+
+          vectorString += "/" + element.getAttribute("data-cvss-tag") + ":" + value;
         }
       });
       var output = CVSS.calculateCVSSFromVector(vectorString);
@@ -1076,337 +880,30 @@
       }
     }
 
-    function updateDropdown(score){
+    function updateDropdown(score) {
       var vector = score.trim().split("/");
 
-      for(var i in vector){
-        var part = vector[i];
+      for (var index = 1; index < vector.length; index++) {
+        var parts = vector[index].split(":");
+        var metric = parts[0].toUpperCase();
+        var metric_value = parts[1].toUpperCase();
 
-        if (part.length > 0){
-          part = part.toUpperCase();
+        if (metric_value == "_" || metric_value == "X") {
+          // Set the value to None
+          metric_value = "N";
         }
 
-        //CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N/RL:O/CR:L
-        // AV
-        // LANP
-        if(part.includes("AV:") && !part.includes("MAV:")){
-          if(part.includes(":L")){
-            document.getElementById('attack_vector').selectedIndex=0;
-          }
-          if(part.includes(":A")){
-            document.getElementById('attack_vector').selectedIndex=1;
-          }
-          if(part.includes(":N")){
-            document.getElementById('attack_vector').selectedIndex=2;
-          }
-          if(part.includes(":P")){
-            document.getElementById('attack_vector').selectedIndex=3;
-          }
-        }
+        selectCVSSByVal(document.querySelector("[data-cvss-tag='" + metric + "']"), metric_value);
+      }
+    }
 
-        // AC
-        if(part.includes("AC:")  && !part.includes("MAC:")){
-          if(part.includes(":L")){
-            document.getElementById('attack_complexity').selectedIndex=0;
-          }
-          if(part.includes(":H")){
-            document.getElementById('attack_complexity').selectedIndex=1;
-          }
-        }
+    function selectCVSSByVal(select, value) {
+      for (var index = 0; index < select.options.length; index++) {
+        var option = select.options[index];
 
-        // PR NLH
-        if(part.includes("PR:")  && !part.includes("MPR:")){
-          if(part.includes(":N")){
-            document.getElementById('privileges_required').selectedIndex=0;
-          }
-          if(part.includes(":L")){
-            document.getElementById('privileges_required').selectedIndex=1;
-          }
-          if(part.includes(":H")){
-            document.getElementById('privileges_required').selectedIndex=2;
-          }
-        }
-
-        // UI
-        if(part.includes("UI:")){
-          if(part.includes(":N")){
-            document.getElementById('user_interaction').selectedIndex=0;
-          }
-          if(part.includes(":R")){
-            document.getElementById('user_interaction').selectedIndex=1;
-          }
-        }
-
-        // S
-        if(part.includes("S:")  && !part.includes("MS:")){
-          if(part.includes(":U")){
-            document.getElementById('scope').selectedIndex=0;
-          }
-          if(part.includes(":C")){
-            document.getElementById('scope').selectedIndex=1;
-          }
-        }
-
-        // I
-        if(part.includes("I:")  && !part.includes("MI:")){
-          if(part.includes(":N")){
-            document.getElementById('integrity').selectedIndex=0;
-          }
-          if(part.includes(":L")){
-            document.getElementById('integrity').selectedIndex=1;
-          }
-          if(part.includes(":H")){
-            document.getElementById('integrity').selectedIndex=2;
-          }
-        }
-
-        // C
-        if(part.includes("C:") && !part.includes("MC:") && !part.includes("MAC:")){
-          if(part.includes(":N")){
-            document.getElementById('confidentiality-impact').selectedIndex=0;
-          }
-          if(part.includes(":L")){
-            document.getElementById('confidentiality-impact').selectedIndex=1;
-          }
-          if(part.includes(":H")){
-            document.getElementById('confidentiality-impact').selectedIndex=2;
-          }
-        }
-
-        // A
-        if(part.includes("A:")  && !part.includes("MA:")){
-          if(part.includes(":N")){
-            document.getElementById('availability').selectedIndex=0;
-          }
-          if(part.includes(":L")){
-            document.getElementById('availability').selectedIndex=1;
-          }
-          if(part.includes(":H")){
-            document.getElementById('availability').selectedIndex=2;
-          }
-        }
-
-        // Exploit Code Maturity
-        if(part.includes("E:")){
-          if(part.includes(":X")){
-            document.getElementById('exploit_maturity').selectedIndex=0;
-          }
-          if(part.includes(":U")){
-            document.getElementById('exploit_maturity').selectedIndex=1;
-          }
-          if(part.includes(":P")){
-            document.getElementById('exploit_maturity').selectedIndex=2;
-          }
-          if(part.includes(":F")){
-            document.getElementById('exploit_maturity').selectedIndex=3;
-          }
-        }
-
-
-        // Remediation Level
-        if(part.includes("RL:")){
-          if(part.includes(":X")){
-            document.getElementById('remeditation_level').selectedIndex=0;
-          }
-          if(part.includes(":O")){
-            document.getElementById('remeditation_level').selectedIndex=1;
-          }
-          if(part.includes(":T")){
-            document.getElementById('remeditation_level').selectedIndex=2;
-          }
-          if(part.includes(":W")){
-            document.getElementById('remeditation_level').selectedIndex=3;
-          }
-          if(part.includes(":U")){
-            document.getElementById('remeditation_level').selectedIndex=4;
-          }
-        }
-
-
-        // report confidence
-        if(part.includes("RC:")){
-          if(part.includes(":X")){
-            document.getElementById('report_confidence').selectedIndex=0;
-          }
-          if(part.includes(":U")){
-            document.getElementById('report_confidence').selectedIndex=1;
-          }
-          if(part.includes(":R")){
-            document.getElementById('report_confidence').selectedIndex=2;
-          }
-          if(part.includes(":C")){
-            document.getElementById('report_confidence').selectedIndex=3;
-          }
-        }
-
-        // confidentiality-requirement
-        if(part.includes("CR:")){
-          if(part.includes(":X")){
-            document.getElementById('confidentiality_requirement').selectedIndex=0;
-          }
-          if(part.includes(":L")){
-            document.getElementById('confidentiality_requirement').selectedIndex=1;
-          }
-          if(part.includes(":M")){
-            document.getElementById('confidentiality_requirement').selectedIndex=2;
-          }
-          if(part.includes(":H")){
-            document.getElementById('confidentiality_requirement').selectedIndex=3;
-          }
-        }
-
-        // integrity-requirement
-        if(part.includes("IR:")){
-          if(part.includes(":X")){
-            document.getElementById('integrity_requirement').selectedIndex=0;
-          }
-          if(part.includes(":L")){
-            document.getElementById('integrity_requirement').selectedIndex=1;
-          }
-          if(part.includes(":M")){
-            document.getElementById('integrity_requirement').selectedIndex=2;
-          }
-          if(part.includes(":H")){
-            document.getElementById('integrity_requirement').selectedIndex=3;
-          }
-        }
-
-        // integrity-requirement
-        if(part.includes("AR:")){
-          if(part.includes(":X")){
-            document.getElementById('availability_requirement').selectedIndex=0;
-          }
-          if(part.includes(":L")){
-            document.getElementById('availability_requirement').selectedIndex=1;
-          }
-          if(part.includes(":M")){
-            document.getElementById('availability_requirement').selectedIndex=2;
-          }
-          if(part.includes(":H")){
-            document.getElementById('availability_requirement').selectedIndex=3;
-          }
-        }
-
-        // modified-attack-vector
-        if(part.includes("MAV:")){
-          if(part.includes(":X")){
-            document.getElementById('mod_attack_vector').selectedIndex=0;
-          }
-          if(part.includes(":L")){
-            document.getElementById('mod_attack_vector').selectedIndex=1;
-          }
-          if(part.includes(":A")){
-            document.getElementById('mod_attack_vector').selectedIndex=2;
-          }
-          if(part.includes(":N")){
-            document.getElementById('mod_attack_vector').selectedIndex=3;
-          }
-          if(part.includes(":P")){
-            document.getElementById('mod_attack_vector').selectedIndex=4;
-          }
-        }
-
-        // modified-attack-vector
-        if(part.includes("MAC:")){
-          if(part.includes(":X")){
-            document.getElementById('mod_attack_complexity').selectedIndex=0;
-          }
-          if(part.includes(":L")){
-            document.getElementById('mod_attack_complexity').selectedIndex=1;
-          }
-          if(part.includes(":H")){
-            document.getElementById('mod_attack_complexity').selectedIndex=2;
-          }
-        }
-
-        // modified-privileges-Required
-        if(part.includes("MPR:")){
-          if(part.includes(":X")){
-            document.getElementById('mod_privileges_required').selectedIndex=0;
-          }
-          if(part.includes(":N")){
-            document.getElementById('mod_privileges_required').selectedIndex=1;
-          }
-          if(part.includes(":L")){
-            document.getElementById('mod_privileges_required').selectedIndex=2;
-          }
-          if(part.includes(":H")){
-            document.getElementById('mod_privileges_required').selectedIndex=3;
-          }
-        }
-
-        // modified-user-interaction
-        if(part.includes("MUI:")){
-          if(part.includes(":X")){
-            document.getElementById('mod_user_interaction').selectedIndex=0;
-          }
-          if(part.includes(":N")){
-            document.getElementById('mod_user_interaction').selectedIndex=1;
-          }
-          if(part.includes(":R")){
-            document.getElementById('mod_user_interaction').selectedIndex=2;
-          }
-        }
-
-        // modified-scope
-        if(part.includes("MS:")){
-          if(part.includes(":X")){
-            document.getElementById('mod_scope').selectedIndex=0;
-          }
-          if(part.includes(":U")){
-            document.getElementById('mod_scope').selectedIndex=1;
-          }
-          if(part.includes(":C")){
-            document.getElementById('mod_scope').selectedIndex=2;
-          }
-        }
-
-        // modified-confidentiality
-        if(part.includes("MC:")){
-          if(part.includes(":X")){
-            document.getElementById('mod_confidentiality').selectedIndex=0;
-          }
-          if(part.includes(":N")){
-            document.getElementById('mod_confidentiality').selectedIndex=1;
-          }
-          if(part.includes(":L")){
-            document.getElementById('mod_confidentiality').selectedIndex=2;
-          }
-          if(part.includes(":H")){
-            document.getElementById('mod_confidentiality').selectedIndex=3;
-          }
-        }
-
-        // modified-integrity
-        if(part.includes("MI:")){
-          if(part.includes(":X")){
-            document.getElementById('mod_integrity').selectedIndex=0;
-          }
-          if(part.includes(":N")){
-            document.getElementById('mod_integrity').selectedIndex=1;
-          }
-          if(part.includes(":L")){
-            document.getElementById('mod_integrity').selectedIndex=2;
-          }
-          if(part.includes(":H")){
-            document.getElementById('mod_integrity').selectedIndex=3;
-          }
-        }
-
-        // modified-availability
-        if(part.includes("MA:")){
-          if(part.includes(":X")){
-            document.getElementById('mod_availability').selectedIndex=0;
-          }
-          if(part.includes(":N")){
-            document.getElementById('mod_availability').selectedIndex=1;
-          }
-          if(part.includes(":L")){
-            document.getElementById('mod_availability').selectedIndex=2;
-          }
-          if(part.includes(":H")){
-            document.getElementById('mod_availability').selectedIndex=3;
-          }
+        if (option.value[0].toUpperCase() == value.toUpperCase()) {
+          select.value = option.value;
+          return;
         }
       }
     }
@@ -1420,7 +917,7 @@
         }
       });
 
-      $(".cvss3 select").on("change", updateCVSS);
+      $(".cvss3 select, .cvss2 select").on("change", updateCVSS);
       updateCVSSSummary(true);
 
       $("#vs").on('change keydown paste input', function(){

--- a/views/findings_edit.haml
+++ b/views/findings_edit.haml
@@ -403,11 +403,11 @@
                 }
                 }
                 }}
-                var c = new CVSS("cvssboard", {
+                var c = new CVSS.js("cvssboard", {
                 onchange: function() {
-                window.location.hash = c.get().vector;
-                document.getElementById('vs').value = c.get().vector;
-                updateDropdown(c.get().vector);
+                window.location.hash = cvssjs.get().vector;
+                document.getElementById('vs').value = cvssjs.get().vector;
+                updateDropdown(cvssjs.get().vector);ç
                 }
                 });
 
@@ -541,7 +541,7 @@
               - else
                 %option #{ar}
     - elsif @cvssv3
-      .control-group
+      .control-group.cvss3
         %label{ :class => "control-label", :for => "attack_vector" }
           %a{:href=> '#mymodal', "data-toggle"=>'modal', :class=>'btn btn-info'}
             CVSS Vector String
@@ -555,550 +555,225 @@
               CVSS Vector String
           .modal-body
             %link{ :rel=>"stylesheet", :type=>"text/css", :media=>"all", :href=>"/css/cvss.css"}
+            %script{:src => "/js/cvsscalc30.js"}
             %script{ :src => "/js/cvss3.js"}
             %div{ :id=>"cvssboard"}
-              %script
-                function updateDropdown(score){
-
-                var vector = score.trim().split("/");
-                for(var i in vector){
-                var part = vector[i];
-
-                if (part.length > 0){
-                part = part.toUpperCase();
-                }
-
-                //CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N/RL:O/CR:L
-                // AV
-                // LANP
-                if(part.includes("AV:") && !part.includes("MAV:")){
-                if(part.includes(":L")){
-                document.getElementById('attack_vector').selectedIndex=0;
-                }
-                if(part.includes(":A")){
-                document.getElementById('attack_vector').selectedIndex=1;
-                }
-                if(part.includes(":N")){
-                document.getElementById('attack_vector').selectedIndex=2;
-                }
-                if(part.includes(":P")){
-                document.getElementById('attack_vector').selectedIndex=3;
-                }
-                }
-
-                // AC
-                if(part.includes("AC:")  && !part.includes("MAC:")){
-                if(part.includes(":L")){
-                document.getElementById('attack_complexity').selectedIndex=0;
-                }
-                if(part.includes(":H")){
-                document.getElementById('attack_complexity').selectedIndex=1;
-                }
-                }
-
-                // PR NLH
-                if(part.includes("PR:")  && !part.includes("MPR:")){
-                if(part.includes(":N")){
-                document.getElementById('privileges_required').selectedIndex=0;
-                }
-                if(part.includes(":L")){
-                document.getElementById('privileges_required').selectedIndex=1;
-                }
-                if(part.includes(":H")){
-                document.getElementById('privileges_required').selectedIndex=2;
-                }
-                }
-
-                // UI
-                if(part.includes("UI:")){
-                if(part.includes(":N")){
-                document.getElementById('user_interaction').selectedIndex=0;
-                }
-                if(part.includes(":R")){
-                document.getElementById('user_interaction').selectedIndex=1;
-                }
-                }
-
-                // S
-                if(part.includes("S:")  && !part.includes("MS:")){
-                if(part.includes(":U")){
-                document.getElementById('scope').selectedIndex=0;
-                }
-                if(part.includes(":C")){
-                document.getElementById('scope').selectedIndex=1;
-                }
-                }
-
-                // I
-                if(part.includes("I:")  && !part.includes("MI:")){
-                if(part.includes(":N")){
-                document.getElementById('integrity').selectedIndex=0;
-                }
-                if(part.includes(":L")){
-                document.getElementById('integrity').selectedIndex=1;
-                }
-                if(part.includes(":H")){
-                document.getElementById('integrity').selectedIndex=2;
-                }
-                }
-
-                // C
-                if(part.includes("C:") && !part.includes("MC:") && !part.includes("MAC:")){
-                if(part.includes(":N")){
-                document.getElementById('confidentiality-impact').selectedIndex=0;
-                }
-                if(part.includes(":L")){
-                document.getElementById('confidentiality-impact').selectedIndex=1;
-                }
-                if(part.includes(":H")){
-                document.getElementById('confidentiality-impact').selectedIndex=2;
-                }
-                }
-
-                // A
-                if(part.includes("A:")  && !part.includes("MA:")){
-                if(part.includes(":N")){
-                document.getElementById('availability').selectedIndex=0;
-                }
-                if(part.includes(":L")){
-                document.getElementById('availability').selectedIndex=1;
-                }
-                if(part.includes(":H")){
-                document.getElementById('availability').selectedIndex=2;
-                }
-                }
-
-                // Exploit Code Maturity
-                if(part.includes("E:")){
-                if(part.includes(":X")){
-                document.getElementById('exploit_maturity').selectedIndex=0;
-                }
-                if(part.includes(":U")){
-                document.getElementById('exploit_maturity').selectedIndex=1;
-                }
-                if(part.includes(":P")){
-                document.getElementById('exploit_maturity').selectedIndex=2;
-                }
-                if(part.includes(":F")){
-                document.getElementById('exploit_maturity').selectedIndex=3;
-                }
-                }
-
-
-                // Remediation Level
-                if(part.includes("RL:")){
-                if(part.includes(":X")){
-                document.getElementById('remeditation_level').selectedIndex=0;
-                }
-                if(part.includes(":O")){
-                document.getElementById('remeditation_level').selectedIndex=1;
-                }
-                if(part.includes(":T")){
-                document.getElementById('remeditation_level').selectedIndex=2;
-                }
-                if(part.includes(":W")){
-                document.getElementById('remeditation_level').selectedIndex=3;
-                }
-                if(part.includes(":U")){
-                document.getElementById('remeditation_level').selectedIndex=4;
-                }
-                }
-
-
-                // report confidence
-                if(part.includes("RC:")){
-                if(part.includes(":X")){
-                document.getElementById('report_confidence').selectedIndex=0;
-                }
-                if(part.includes(":U")){
-                document.getElementById('report_confidence').selectedIndex=1;
-                }
-                if(part.includes(":R")){
-                document.getElementById('report_confidence').selectedIndex=2;
-                }
-                if(part.includes(":C")){
-                document.getElementById('report_confidence').selectedIndex=3;
-                }
-                }
-
-                // confidentiality-requirement
-                if(part.includes("CR:")){
-                if(part.includes(":X")){
-                document.getElementById('confidentiality_requirement').selectedIndex=0;
-                }
-                if(part.includes(":L")){
-                document.getElementById('confidentiality_requirement').selectedIndex=1;
-                }
-                if(part.includes(":M")){
-                document.getElementById('confidentiality_requirement').selectedIndex=2;
-                }
-                if(part.includes(":H")){
-                document.getElementById('confidentiality_requirement').selectedIndex=3;
-                }
-                }
-
-                // integrity-requirement
-                if(part.includes("IR:")){
-                if(part.includes(":X")){
-                document.getElementById('integrity_requirement').selectedIndex=0;
-                }
-                if(part.includes(":L")){
-                document.getElementById('integrity_requirement').selectedIndex=1;
-                }
-                if(part.includes(":M")){
-                document.getElementById('integrity_requirement').selectedIndex=2;
-                }
-                if(part.includes(":H")){
-                document.getElementById('integrity_requirement').selectedIndex=3;
-                }
-                }
-
-
-                // integrity-requirement
-                if(part.includes("AR:")){
-                if(part.includes(":X")){
-                document.getElementById('availability_requirement').selectedIndex=0;
-                }
-                if(part.includes(":L")){
-                document.getElementById('availability_requirement').selectedIndex=1;
-                }
-                if(part.includes(":M")){
-                document.getElementById('availability_requirement').selectedIndex=2;
-                }
-                if(part.includes(":H")){
-                document.getElementById('availability_requirement').selectedIndex=3;
-                }
-                }
-
-                // modified-attack-vector
-                if(part.includes("MAV:")){
-                if(part.includes(":X")){
-                document.getElementById('mod_attack_vector').selectedIndex=0;
-                }
-                if(part.includes(":L")){
-                document.getElementById('mod_attack_vector').selectedIndex=1;
-                }
-                if(part.includes(":A")){
-                document.getElementById('mod_attack_vector').selectedIndex=2;
-                }
-                if(part.includes(":N")){
-                document.getElementById('mod_attack_vector').selectedIndex=3;
-                }
-                if(part.includes(":P")){
-                document.getElementById('mod_attack_vector').selectedIndex=4;
-                }
-                }
-
-                // modified-attack-vector
-                if(part.includes("MAC:")){
-                if(part.includes(":X")){
-                document.getElementById('mod_attack_complexity').selectedIndex=0;
-                }
-                if(part.includes(":L")){
-                document.getElementById('mod_attack_complexity').selectedIndex=1;
-                }
-                if(part.includes(":H")){
-                document.getElementById('mod_attack_complexity').selectedIndex=2;
-                }
-                }
-
-                // modified-privileges-Required
-                if(part.includes("MPR:")){
-                if(part.includes(":X")){
-                document.getElementById('mod_privileges_required').selectedIndex=0;
-                }
-                if(part.includes(":N")){
-                document.getElementById('mod_privileges_required').selectedIndex=1;
-                }
-                if(part.includes(":L")){
-                document.getElementById('mod_privileges_required').selectedIndex=2;
-                }
-                if(part.includes(":H")){
-                document.getElementById('mod_privileges_required').selectedIndex=3;
-                }
-                }
-
-                // modified-user-interaction
-                if(part.includes("MUI:")){
-                if(part.includes(":X")){
-                document.getElementById('mod_user_interaction').selectedIndex=0;
-                }
-                if(part.includes(":N")){
-                document.getElementById('mod_user_interaction').selectedIndex=1;
-                }
-                if(part.includes(":R")){
-                document.getElementById('mod_user_interaction').selectedIndex=2;
-                }
-                }
-
-
-                // modified-scope
-                if(part.includes("MS:")){
-                if(part.includes(":X")){
-                document.getElementById('mod_scope').selectedIndex=0;
-                }
-                if(part.includes(":U")){
-                document.getElementById('mod_scope').selectedIndex=1;
-                }
-                if(part.includes(":C")){
-                document.getElementById('mod_scope').selectedIndex=2;
-                }
-                }
-
-                // modified-confidentiality
-                if(part.includes("MC:")){
-                if(part.includes(":X")){
-                document.getElementById('mod_confidentiality').selectedIndex=0;
-                }
-                if(part.includes(":N")){
-                document.getElementById('mod_confidentiality').selectedIndex=1;
-                }
-                if(part.includes(":L")){
-                document.getElementById('mod_confidentiality').selectedIndex=2;
-                }
-                if(part.includes(":H")){
-                document.getElementById('mod_confidentiality').selectedIndex=3;
-                }
-                }
-
-                // modified-integrity
-                if(part.includes("MI:")){
-                if(part.includes(":X")){
-                document.getElementById('mod_integrity').selectedIndex=0;
-                }
-                if(part.includes(":N")){
-                document.getElementById('mod_integrity').selectedIndex=1;
-                }
-                if(part.includes(":L")){
-                document.getElementById('mod_integrity').selectedIndex=2;
-                }
-                if(part.includes(":H")){
-                document.getElementById('mod_integrity').selectedIndex=3;
-                }
-                }
-
-
-                // modified-availability
-                if(part.includes("MA:")){
-                if(part.includes(":X")){
-                document.getElementById('mod_availability').selectedIndex=0;
-                }
-                if(part.includes(":N")){
-                document.getElementById('mod_availability').selectedIndex=1;
-                }
-                if(part.includes(":L")){
-                document.getElementById('mod_availability').selectedIndex=2;
-                }
-                if(part.includes(":H")){
-                document.getElementById('mod_availability').selectedIndex=3;
-                }
-                }
-                }}
-
-                var c = new CVSS("cvssboard", {
-                onchange: function() {
-                document.getElementById('vs').value = c.get().vector;
-                updateDropdown(c.get().vector);
-                }
-                });
-
-                $("#vs").on('change keydown paste input', function(){
-                updateDropdown(this.value);
-                });
       %span{:class=>"input-group-btn"}
-      .control-group
+      .control-group.cvss3
+        %label{ :class => "control-label", :for => "attack_vector" } Base Score
+        .controls
+          #baseScore.cvssjs
+            .results
+              %span.score
+              %span.severity
+      .control-group.cvss3
+        %label{ :class => "control-label", :for => "attack_vector" } Temporal Score
+        .controls
+          #temporalScore.cvssjs
+            .results
+              %span.score
+              %span.severity
+      .control-group.cvss3
+        %label{ :class => "control-label", :for => "attack_vector" } Environmental Score
+        .controls
+          #environmentalScore.cvssjs
+            .results
+              %span.score
+              %span.severity
+
+      .control-group.cvss3
         %label{ :class => "control-label", :for => "attack_vector" } Attack Vector
         .controls
-          %select{ :name => "attack_vector", :id => "attack_vector"  }
+          %select{ :name => "attack_vector", :id => "attack_vector", "data-cvss-tag" => "AV"  }
             - options.attack_vector.each do |attack_vector|
               - if attack_vector == @finding.attack_vector
                 %option{ :selected => "selected" } #{attack_vector}
               - else
                 %option #{attack_vector}
-      .control-group
+      .control-group.cvss3
         %label{ :class => "control-label", :for => "attack_complexity" } Attack Complexity
         .controls
-          %select{ :name => "attack_complexity", :id =>  "attack_complexity" }
+          %select{ :name => "attack_complexity", :id =>  "attack_complexity", "data-cvss-tag" => "AC" }
             - options.attack_complexity.each do |attack_complexity|
               - if attack_complexity == @finding.attack_complexity
                 %option{ :selected => "selected" } #{attack_complexity}
               - else
                 %option #{attack_complexity}
-      .control-group
+      .control-group.cvss3
         %label{ :class => "control-label", :for => "privileges_required" } Privileges Required
         .controls
-          %select{ :name => "privileges_required", :id =>  "privileges_required" }
+          %select{ :name => "privileges_required", :id =>  "privileges_required", "data-cvss-tag" => "PR" }
             - options.privileges_required.each do |privileges_required|
               - if privileges_required == @finding.privileges_required
                 %option{ :selected => "selected" } #{privileges_required}
               - else
                 %option #{privileges_required}
-      .control-group
+      .control-group.cvss3
         %label{ :class => "control-label", :for => "user_interaction" } User Interaction
         .controls
-          %select{ :name => "user_interaction", :id => "user_interaction"  }
+          %select{ :name => "user_interaction", :id => "user_interaction", "data-cvss-tag" => "UI"  }
             - options.user_interaction.each do |user_interaction|
               - if user_interaction == @finding.user_interaction
                 %option{ :selected => "selected" } #{user_interaction}
               - else
                 %option #{user_interaction}
-      .control-group
+      .control-group.cvss3
         %label{ :class => "control-label", :for => "scope_cvss" } Scope
         .controls
-          %select{ :name => "scope_cvss", :id => "scope"  }
+          %select{ :name => "scope_cvss", :id => "scope", "data-cvss-tag" => "S"  }
             - options.scope_cvss.each do |scope_cvss|
               - if scope_cvss == @finding.scope_cvss
                 %option{ :selected => "selected" } #{scope_cvss}
               - else
                 %option #{scope_cvss}
-      .control-group
+      .control-group.cvss3
         %label{ :class => "control-label", :for => "confidentiality" } Confidentiality
         .controls
-          %select{ :name => "confidentiality", :id => "confidentiality-impact" }
+          %select{ :name => "confidentiality", :id => "confidentiality-impact", "data-cvss-tag" => "C" }
             - options.confidentiality.each do |confidentiality|
               - if confidentiality == @finding.confidentiality
                 %option{ :selected => "selected" } #{confidentiality}
               - else
                 %option #{confidentiality}
-      .control-group
+      .control-group.cvss3
         %label{ :class => "control-label", :for => "integrity" } Integrity
         .controls
-          %select{ :name => "integrity", :id => "integrity" }
+          %select{ :name => "integrity", :id => "integrity", "data-cvss-tag" => "I" }
             - options.integrity.each do |integrity|
               - if integrity == @finding.integrity
                 %option{ :selected => "selected" } #{integrity}
               - else
                 %option #{integrity}
-      .control-group
+      .control-group.cvss3
         %label{ :class => "control-label", :for => "availability" } Availability
         .controls
-          %select{ :name => "availability", :id => "availability" }
+          %select{ :name => "availability", :id => "availability", "data-cvss-tag" => "A" }
             - options.availability.each do |availability|
               - if availability == @finding.availability
                 %option{ :selected => "selected" } #{availability}
               - else
                 %option #{availability}
-      .control-group
+      .control-group.cvss3
         %label{ :class => "control-label", :for => "exploit_maturity" } Exploit Code Maturity
         .controls
-          %select{ :name => "exploit_maturity", :id => "exploit_maturity"  }
+          %select{ :name => "exploit_maturity", :id => "exploit_maturity", "data-cvss-tag" => "E"  }
             - options.exploit_maturity.each do |exploit_maturity|
               - if exploit_maturity == @finding.exploit_maturity
                 %option{ :selected => "selected" } #{exploit_maturity}
               - else
                 %option #{exploit_maturity}
-      .control-group
+      .control-group.cvss3
         %label{ :class => "control-label", :for => "remeditation_level" } Remediation Level
         .controls
-          %select{ :name => "remeditation_level", :id => "remeditation_level" }
+          %select{ :name => "remeditation_level", :id => "remeditation_level", "data-cvss-tag" => "RL" }
             - options.remeditation_level.each do |remeditation_level|
               - if remeditation_level == @finding.remeditation_level
                 %option{ :selected => "selected" } #{remeditation_level}
               - else
                 %option #{remeditation_level}
-      .control-group
+      .control-group.cvss3
         %label{ :class => "control-label", :for => "report_confidence" } Report Confidence
         .controls
-          %select{ :name => "report_confidence", :id => "report_confidence" }
+          %select{ :name => "report_confidence", :id => "report_confidence", "data-cvss-tag" => "RC" }
             - options.report_confidence.each do |report_confidence|
               - if report_confidence == @finding.report_confidence
                 %option{ :selected => "selected" } #{report_confidence}
               - else
                 %option #{report_confidence}
-      .control-group
+      .control-group.cvss3
         %label{ :class => "control-label", :for => "confidentiality_requirement" } Confidentiality Requirement
         .controls
-          %select{ :name => "confidentiality_requirement", :id => "confidentiality_requirement"  }
+          %select{ :name => "confidentiality_requirement", :id => "confidentiality_requirement", "data-cvss-tag" => "CR" }
             - options.confidentiality_requirement.each do |confidentiality_requirement|
               - if confidentiality_requirement == @finding.confidentiality_requirement
                 %option{ :selected => "selected" } #{confidentiality_requirement}
               - else
                 %option #{confidentiality_requirement}
-      .control-group
+      .control-group.cvss3
         %label{ :class => "control-label", :for => "integrity_requirement" } Integrity Requirement
         .controls
-          %select{ :name => "integrity_requirement", :id => "integrity_requirement" }
+          %select{ :name => "integrity_requirement", :id => "integrity_requirement", "data-cvss-tag" => "IR" }
             - options.integrity_requirement.each do |integrity_requirement|
               - if integrity_requirement == @finding.integrity_requirement
                 %option{ :selected => "selected" } #{integrity_requirement}
               - else
                 %option #{integrity_requirement}
-      .control-group
+      .control-group.cvss3
         %label{ :class => "control-label", :for => "availability_requirement" } Availability Requirement
         .controls
-          %select{ :name => "availability_requirement", :id => "availability_requirement" }
+          %select{ :name => "availability_requirement", :id => "availability_requirement", "data-cvss-tag" => "AR" }
             - options.availability_requirement.each do |availability_requirement|
               - if availability_requirement == @finding.availability_requirement
                 %option{ :selected => "selected" } #{availability_requirement}
               - else
                 %option #{availability_requirement}
-      .control-group
+      .control-group.cvss3
         %label{ :class => "control-label", :for => "mod_attack_vector" } Modified Attack Vector
         .controls
-          %select{ :name => "mod_attack_vector", :id => "mod_attack_vector" }
+          %select{ :name => "mod_attack_vector", :id => "mod_attack_vector", "data-cvss-tag" => "MAV" }
             - options.mod_attack_vector.each do |mod_attack_vector|
               - if mod_attack_vector == @finding.mod_attack_vector
                 %option{ :selected => "selected" } #{mod_attack_vector}
               - else
                 %option #{mod_attack_vector}
-      .control-group
+      .control-group.cvss3
         %label{ :class => "control-label", :for => "mod_attack_complexity" } Modified Attack Complexity
         .controls
-          %select{ :name => "mod_attack_complexity", :id => "mod_attack_complexity" }
+          %select{ :name => "mod_attack_complexity", :id => "mod_attack_complexity", "data-cvss-tag" => "MAC" }
             - options.mod_attack_complexity.each do |mod_attack_complexity|
               - if mod_attack_complexity == @finding.mod_attack_complexity
                 %option{ :selected => "selected" } #{mod_attack_complexity}
               - else
                 %option #{mod_attack_complexity}
-      .control-group
+      .control-group.cvss3
         %label{ :class => "control-label", :for => "mod_privileges_required" } Modified Privileges Required
         .controls
-          %select{ :name => "mod_privileges_required", :id => "mod_privileges_required" }
+          %select{ :name => "mod_privileges_required", :id => "mod_privileges_required", "data-cvss-tag" => "MPR" }
             - options.mod_privileges_required.each do |mod_privileges_required|
               - if mod_privileges_required == @finding.mod_privileges_required
                 %option{ :selected => "selected" } #{mod_privileges_required}
               - else
                 %option #{mod_privileges_required}
-      .control-group
+      .control-group.cvss3
         %label{ :class => "control-label", :for => "mod_user_interaction" } Modified User Interaction
         .controls
-          %select{ :name => "mod_user_interaction", :id => "mod_user_interaction" }
+          %select{ :name => "mod_user_interaction", :id => "mod_user_interaction", "data-cvss-tag" => "MUI" }
             - options.mod_user_interaction.each do |mod_user_interaction|
               - if mod_user_interaction == @finding.mod_user_interaction
                 %option{ :selected => "selected" } #{mod_user_interaction}
               - else
                 %option #{mod_user_interaction}
-      .control-group
+      .control-group.cvss3
         %label{ :class => "control-label", :for => "mod_scope" } Modified Scope
         .controls
-          %select{ :name => "mod_scope", :id => "mod_scope" }
+          %select{ :name => "mod_scope", :id => "mod_scope", "data-cvss-tag" => "MS" }
             - options.mod_scope.each do |mod_scope|
               - if mod_scope == @finding.mod_scope
                 %option{ :selected => "selected" } #{mod_scope}
               - else
                 %option #{mod_scope}
-      .control-group
+      .control-group.cvss3
         %label{ :class => "control-label", :for => "mod_confidentiality" } Modified Confidentiality
         .controls
-          %select{ :name => "mod_confidentiality", :id => "mod_confidentiality" }
+          %select{ :name => "mod_confidentiality", :id => "mod_confidentiality", "data-cvss-tag" => "MC" }
             - options.mod_confidentiality.each do |mod_confidentiality|
               - if mod_confidentiality == @finding.mod_confidentiality
                 %option{ :selected => "selected" } #{mod_confidentiality}
               - else
                 %option #{mod_confidentiality}
-      .control-group
+      .control-group.cvss3
         %label{ :class => "control-label", :for => "mod_integrity" } Modified Integrity
         .controls
-          %select{ :name => "mod_integrity", :id => "mod_integrity" }
+          %select{ :name => "mod_integrity", :id => "mod_integrity", "data-cvss-tag" => "MI" }
             - options.mod_integrity.each do |mod_integrity|
               - if mod_integrity == @finding.mod_integrity
                 %option{ :selected => "selected" } #{mod_integrity}
               - else
                 %option #{mod_integrity}
-      .control-group
+      .control-group.cvss3
         %label{ :class => "control-label", :for => "mod_availability" } Modified Availability
         .controls
-          %select{ :name => "mod_availability", :id => "mod_availability" }
+          %select{ :name => "mod_availability", :id => "mod_availability", "data-cvss-tag" => "MA" }
             - options.mod_availability.each do |mod_availability|
               - if mod_availability == @finding.mod_availability
                 %option{ :selected => "selected" } #{mod_availability}
@@ -1360,3 +1035,398 @@
   for (var index = 0, length = deleteElements.length; index < length; index++) {
     deleteElements[index].addEventListener('click', confirmDelete, false);
   }
+
+-if @cvssv3
+  :css
+    .cvss3 .cvssjs .results {
+      padding: 0px;
+    }
+
+  :javascript
+    var cvssjs;
+
+    function updateCVSS() {
+      updateCVSSSummary(true);
+    }
+
+    function updateCVSSSummary(updateCVSSJS) {
+      var vectorString = "";
+
+      vectorString = "CVSS:3.0";
+
+      $("select[data-cvss-tag]").each(function (index, element) {
+        if (element.value.toLowerCase() == "not defined") {
+          vectorString += "/" + element.getAttribute("data-cvss-tag") + ":X";
+        } else {
+          vectorString += "/" + element.getAttribute("data-cvss-tag") + ":" + element.value[0];
+        }
+      });
+      var output = CVSS.calculateCVSSFromVector(vectorString);
+
+      $("#baseScore .results .score").text(output.baseMetricScore);
+      $("#baseScore .results .severity").text(output.baseSeverity);
+      $("#baseScore .results .severity").attr("class", "severity " + output.baseSeverity);
+      $("#temporalScore .results .score").text(output.temporalMetricScore);
+      $("#temporalScore .results .severity").text(output.temporalSeverity);
+      $("#temporalScore .results .severity").attr("class", "severity " + output.temporalSeverity);
+      $("#environmentalScore .results .score").text(output.environmentalMetricScore);
+      $("#environmentalScore .results .severity").text(output.environmentalSeverity);
+      $("#environmentalScore .results .severity").attr("class", "severity " + output.environmentalSeverity);
+
+      if (updateCVSSJS) {
+        cvssjs.set(vectorString);
+      }
+    }
+
+    function updateDropdown(score){
+      var vector = score.trim().split("/");
+
+      for(var i in vector){
+        var part = vector[i];
+
+        if (part.length > 0){
+          part = part.toUpperCase();
+        }
+
+        //CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N/RL:O/CR:L
+        // AV
+        // LANP
+        if(part.includes("AV:") && !part.includes("MAV:")){
+          if(part.includes(":L")){
+            document.getElementById('attack_vector').selectedIndex=0;
+          }
+          if(part.includes(":A")){
+            document.getElementById('attack_vector').selectedIndex=1;
+          }
+          if(part.includes(":N")){
+            document.getElementById('attack_vector').selectedIndex=2;
+          }
+          if(part.includes(":P")){
+            document.getElementById('attack_vector').selectedIndex=3;
+          }
+        }
+
+        // AC
+        if(part.includes("AC:")  && !part.includes("MAC:")){
+          if(part.includes(":L")){
+            document.getElementById('attack_complexity').selectedIndex=0;
+          }
+          if(part.includes(":H")){
+            document.getElementById('attack_complexity').selectedIndex=1;
+          }
+        }
+
+        // PR NLH
+        if(part.includes("PR:")  && !part.includes("MPR:")){
+          if(part.includes(":N")){
+            document.getElementById('privileges_required').selectedIndex=0;
+          }
+          if(part.includes(":L")){
+            document.getElementById('privileges_required').selectedIndex=1;
+          }
+          if(part.includes(":H")){
+            document.getElementById('privileges_required').selectedIndex=2;
+          }
+        }
+
+        // UI
+        if(part.includes("UI:")){
+          if(part.includes(":N")){
+            document.getElementById('user_interaction').selectedIndex=0;
+          }
+          if(part.includes(":R")){
+            document.getElementById('user_interaction').selectedIndex=1;
+          }
+        }
+
+        // S
+        if(part.includes("S:")  && !part.includes("MS:")){
+          if(part.includes(":U")){
+            document.getElementById('scope').selectedIndex=0;
+          }
+          if(part.includes(":C")){
+            document.getElementById('scope').selectedIndex=1;
+          }
+        }
+
+        // I
+        if(part.includes("I:")  && !part.includes("MI:")){
+          if(part.includes(":N")){
+            document.getElementById('integrity').selectedIndex=0;
+          }
+          if(part.includes(":L")){
+            document.getElementById('integrity').selectedIndex=1;
+          }
+          if(part.includes(":H")){
+            document.getElementById('integrity').selectedIndex=2;
+          }
+        }
+
+        // C
+        if(part.includes("C:") && !part.includes("MC:") && !part.includes("MAC:")){
+          if(part.includes(":N")){
+            document.getElementById('confidentiality-impact').selectedIndex=0;
+          }
+          if(part.includes(":L")){
+            document.getElementById('confidentiality-impact').selectedIndex=1;
+          }
+          if(part.includes(":H")){
+            document.getElementById('confidentiality-impact').selectedIndex=2;
+          }
+        }
+
+        // A
+        if(part.includes("A:")  && !part.includes("MA:")){
+          if(part.includes(":N")){
+            document.getElementById('availability').selectedIndex=0;
+          }
+          if(part.includes(":L")){
+            document.getElementById('availability').selectedIndex=1;
+          }
+          if(part.includes(":H")){
+            document.getElementById('availability').selectedIndex=2;
+          }
+        }
+
+        // Exploit Code Maturity
+        if(part.includes("E:")){
+          if(part.includes(":X")){
+            document.getElementById('exploit_maturity').selectedIndex=0;
+          }
+          if(part.includes(":U")){
+            document.getElementById('exploit_maturity').selectedIndex=1;
+          }
+          if(part.includes(":P")){
+            document.getElementById('exploit_maturity').selectedIndex=2;
+          }
+          if(part.includes(":F")){
+            document.getElementById('exploit_maturity').selectedIndex=3;
+          }
+        }
+
+
+        // Remediation Level
+        if(part.includes("RL:")){
+          if(part.includes(":X")){
+            document.getElementById('remeditation_level').selectedIndex=0;
+          }
+          if(part.includes(":O")){
+            document.getElementById('remeditation_level').selectedIndex=1;
+          }
+          if(part.includes(":T")){
+            document.getElementById('remeditation_level').selectedIndex=2;
+          }
+          if(part.includes(":W")){
+            document.getElementById('remeditation_level').selectedIndex=3;
+          }
+          if(part.includes(":U")){
+            document.getElementById('remeditation_level').selectedIndex=4;
+          }
+        }
+
+
+        // report confidence
+        if(part.includes("RC:")){
+          if(part.includes(":X")){
+            document.getElementById('report_confidence').selectedIndex=0;
+          }
+          if(part.includes(":U")){
+            document.getElementById('report_confidence').selectedIndex=1;
+          }
+          if(part.includes(":R")){
+            document.getElementById('report_confidence').selectedIndex=2;
+          }
+          if(part.includes(":C")){
+            document.getElementById('report_confidence').selectedIndex=3;
+          }
+        }
+
+        // confidentiality-requirement
+        if(part.includes("CR:")){
+          if(part.includes(":X")){
+            document.getElementById('confidentiality_requirement').selectedIndex=0;
+          }
+          if(part.includes(":L")){
+            document.getElementById('confidentiality_requirement').selectedIndex=1;
+          }
+          if(part.includes(":M")){
+            document.getElementById('confidentiality_requirement').selectedIndex=2;
+          }
+          if(part.includes(":H")){
+            document.getElementById('confidentiality_requirement').selectedIndex=3;
+          }
+        }
+
+        // integrity-requirement
+        if(part.includes("IR:")){
+          if(part.includes(":X")){
+            document.getElementById('integrity_requirement').selectedIndex=0;
+          }
+          if(part.includes(":L")){
+            document.getElementById('integrity_requirement').selectedIndex=1;
+          }
+          if(part.includes(":M")){
+            document.getElementById('integrity_requirement').selectedIndex=2;
+          }
+          if(part.includes(":H")){
+            document.getElementById('integrity_requirement').selectedIndex=3;
+          }
+        }
+
+        // integrity-requirement
+        if(part.includes("AR:")){
+          if(part.includes(":X")){
+            document.getElementById('availability_requirement').selectedIndex=0;
+          }
+          if(part.includes(":L")){
+            document.getElementById('availability_requirement').selectedIndex=1;
+          }
+          if(part.includes(":M")){
+            document.getElementById('availability_requirement').selectedIndex=2;
+          }
+          if(part.includes(":H")){
+            document.getElementById('availability_requirement').selectedIndex=3;
+          }
+        }
+
+        // modified-attack-vector
+        if(part.includes("MAV:")){
+          if(part.includes(":X")){
+            document.getElementById('mod_attack_vector').selectedIndex=0;
+          }
+          if(part.includes(":L")){
+            document.getElementById('mod_attack_vector').selectedIndex=1;
+          }
+          if(part.includes(":A")){
+            document.getElementById('mod_attack_vector').selectedIndex=2;
+          }
+          if(part.includes(":N")){
+            document.getElementById('mod_attack_vector').selectedIndex=3;
+          }
+          if(part.includes(":P")){
+            document.getElementById('mod_attack_vector').selectedIndex=4;
+          }
+        }
+
+        // modified-attack-vector
+        if(part.includes("MAC:")){
+          if(part.includes(":X")){
+            document.getElementById('mod_attack_complexity').selectedIndex=0;
+          }
+          if(part.includes(":L")){
+            document.getElementById('mod_attack_complexity').selectedIndex=1;
+          }
+          if(part.includes(":H")){
+            document.getElementById('mod_attack_complexity').selectedIndex=2;
+          }
+        }
+
+        // modified-privileges-Required
+        if(part.includes("MPR:")){
+          if(part.includes(":X")){
+            document.getElementById('mod_privileges_required').selectedIndex=0;
+          }
+          if(part.includes(":N")){
+            document.getElementById('mod_privileges_required').selectedIndex=1;
+          }
+          if(part.includes(":L")){
+            document.getElementById('mod_privileges_required').selectedIndex=2;
+          }
+          if(part.includes(":H")){
+            document.getElementById('mod_privileges_required').selectedIndex=3;
+          }
+        }
+
+        // modified-user-interaction
+        if(part.includes("MUI:")){
+          if(part.includes(":X")){
+            document.getElementById('mod_user_interaction').selectedIndex=0;
+          }
+          if(part.includes(":N")){
+            document.getElementById('mod_user_interaction').selectedIndex=1;
+          }
+          if(part.includes(":R")){
+            document.getElementById('mod_user_interaction').selectedIndex=2;
+          }
+        }
+
+        // modified-scope
+        if(part.includes("MS:")){
+          if(part.includes(":X")){
+            document.getElementById('mod_scope').selectedIndex=0;
+          }
+          if(part.includes(":U")){
+            document.getElementById('mod_scope').selectedIndex=1;
+          }
+          if(part.includes(":C")){
+            document.getElementById('mod_scope').selectedIndex=2;
+          }
+        }
+
+        // modified-confidentiality
+        if(part.includes("MC:")){
+          if(part.includes(":X")){
+            document.getElementById('mod_confidentiality').selectedIndex=0;
+          }
+          if(part.includes(":N")){
+            document.getElementById('mod_confidentiality').selectedIndex=1;
+          }
+          if(part.includes(":L")){
+            document.getElementById('mod_confidentiality').selectedIndex=2;
+          }
+          if(part.includes(":H")){
+            document.getElementById('mod_confidentiality').selectedIndex=3;
+          }
+        }
+
+        // modified-integrity
+        if(part.includes("MI:")){
+          if(part.includes(":X")){
+            document.getElementById('mod_integrity').selectedIndex=0;
+          }
+          if(part.includes(":N")){
+            document.getElementById('mod_integrity').selectedIndex=1;
+          }
+          if(part.includes(":L")){
+            document.getElementById('mod_integrity').selectedIndex=2;
+          }
+          if(part.includes(":H")){
+            document.getElementById('mod_integrity').selectedIndex=3;
+          }
+        }
+
+        // modified-availability
+        if(part.includes("MA:")){
+          if(part.includes(":X")){
+            document.getElementById('mod_availability').selectedIndex=0;
+          }
+          if(part.includes(":N")){
+            document.getElementById('mod_availability').selectedIndex=1;
+          }
+          if(part.includes(":L")){
+            document.getElementById('mod_availability').selectedIndex=2;
+          }
+          if(part.includes(":H")){
+            document.getElementById('mod_availability').selectedIndex=3;
+          }
+        }
+      }
+    }
+
+    $(document).ready(function() {
+      cvssjs = new CVSS.js("cvssboard", {
+        onchange: function() {
+          document.getElementById('vs').value = cvssjs.get().vector;
+          updateDropdown(cvssjs.get().vector);
+          updateCVSSSummary(false);
+        }
+      });
+
+      $(".cvss3 select").on("change", updateCVSS);
+      updateCVSSSummary(true);
+
+      $("#vs").on('change keydown paste input', function(){
+        updateDropdown(this.value);
+        updateCVSSSummary(true, false);
+      });
+    });

--- a/views/findings_edit.haml
+++ b/views/findings_edit.haml
@@ -8,13 +8,13 @@
   %br
   %form{ :class => "form-horizontal", :method => 'post', :enctype => 'application/x-www-form-urlencoded'}
     .control-group
-      %label{ :class => "control-label", :for => "title" } Title
+      %label.control-label{ :for => "title" } Title
       .controls
         %input{ :type => 'text', :name => 'title', :value => "#{@finding.title}"}
     -if !@master
       %br
       .control-group
-        %label{ :class => "control-label", :for => "assessment_type" } Assessment Type
+        %label.control-label{ :for => "assessment_type" } Assessment Type
         .controls
           %select{ :name => "assessment_type" }
             - options.assessment_types.each do |type|
@@ -25,7 +25,7 @@
                   %option #{type}
     -if @master
       .control-group
-        %label{ :class => "control-label", :for => "approved" } Approved
+        %label.control-label{ :for => "approved" } Approved
         .controls
           -if @finding.approved
             %input{ :type=>"checkbox", :name => 'approved', :checked=>"checked"}
@@ -33,7 +33,7 @@
             %input{ :type=>"checkbox", :name => 'approved'}
       - if @vulnmap
         .control-group
-          %label{ :class => "control-label", :for => "existingvulnmaps" } Vuln IDs mapped to this finding
+          %label.control-label{ :for => "existingvulnmaps" } Vuln IDs mapped to this finding
           .controls
             .table
               %table{ :style => 'width: 220px'}
@@ -46,7 +46,7 @@
                         %a{ :class => "btn btn-danger btn-sm", :href => "/mapping/#{@finding.id}/vulnmap/#{vuln.id}/delete"}
                           %i{:class => 'icon-remove icon-white icon-sm', :value => "#{vuln.msf_ref}", :type => "submit", :title => 'Delete'}
         .control-group
-          %label{ :class => "control-label", :for => "msf_ref" }
+          %label.control-label{ :for => "msf_ref" }
             %a{:href=> '#mymodal', "data-toggle"=>'modal', :class=>'btn btn-info'}
               Add new Vuln ID mapping
           .modal{:id=>'mymodal', :class=>'modal hide fade', :tabindex=>'-1', :role=>'dialog', "aria-labelledby"=>'modal-label', "aria-hidden"=>'true'}
@@ -88,7 +88,7 @@
             %input{ :type => 'text', :name => 'msf_ref'}
       - if @nessusmap
         .control-group
-          %label{ :class => "control-label", :for => "existingnessusmaps" } Nessus IDs Mapped to this finding
+          %label.control-label{ :for => "existingnessusmaps" } Nessus IDs Mapped to this finding
           .controls
             .table
               %table{ :style => 'width: 220px'}
@@ -102,12 +102,12 @@
                         %a{ :class => "btn btn-danger btn-xs", :href => "/mapping/#{@finding.id}/nessus/#{item.pluginid}/delete"}
                           %i{:class => 'icon-remove icon-white', :value => "#{item.pluginid}", :type => "submit", :title => 'Delete'}
         .control-group
-          %label{ :class => "control-label", :for => "nessus_pluginid" } Add new nessus ID mapping
+          %label.control-label{ :for => "nessus_pluginid" } Add new nessus ID mapping
           .controls
             %input{ :type => 'text', :name => 'nessus_pluginid'}
       - if @burpmap
         .control-group
-          %label{ :class => "control-label", :for => "existingburpmaps" } Burp IDs Mapped to this finding
+          %label.control-label{ :for => "existingburpmaps" } Burp IDs Mapped to this finding
           .controls
             .table
               %table{ :style => 'width: 220px'}
@@ -121,7 +121,7 @@
                         %a{ :class => "btn btn-danger btn-xs", :href => "/mapping/#{@finding.id}/burp/#{item.pluginid}/delete"}
                           %i{:class => 'icon-remove icon-white', :value => "#{item.pluginid}", :type => "submit", :title => 'Delete'}
         .control-group
-          %label{ :class => "control-label", :for => "burp_pluginid" }
+          %label.control-label{ :for => "burp_pluginid" }
             %a{:href=> '#burpmodal', "data-toggle"=>'modal'}
               Add new Burp ID mapping
           .modal{:id=>'burpmodal', :class=>'modal hide fade', :tabindex=>'-1', :role=>'dialog', "aria-labelledby"=>'modal-label', "aria-hidden"=>'true'}
@@ -140,28 +140,28 @@
             %input{ :type => 'text', :name => 'burp_pluginid'}
     - if @dread
       .control-group
-        %label{ :class => "control-label", :for => "damage" } Damage
+        %label.control-label{ :for => "damage" } Damage
         .controls
           %input{ :type => 'number', :min => '1', :max => '10', :name => 'damage', :value => "#{@finding.damage}", :required => true}
       .control-group
-        %label{ :class => "control-label", :for => "reproducability" } Reproducibility
+        %label.control-label{ :for => "reproducability" } Reproducibility
         .controls
           %input{ :type => 'number', :min => '1', :max => '10', :name => 'reproducability', :value => "#{@finding.reproducability}", :required => true}
       .control-group
-        %label{ :class => "control-label", :for => "exploitability" } Exploitability
+        %label.control-label{ :for => "exploitability" } Exploitability
         .controls
           %input{ :type => 'number', :min => '1', :max => '10', :name => 'exploitability', :value => "#{@finding.exploitability}", :required => true}
       .control-group
-        %label{ :class => "control-label", :for => "affected_users" } Affected Users
+        %label.control-label{ :for => "affected_users" } Affected Users
         .controls
           %input{ :type => 'number', :min => '1', :max => '10', :name => 'affected_users', :value => "#{@finding.affected_users}", :required => true}
       .control-group
-        %label{ :class => "control-label", :for => "discoverability" } Discoverability
+        %label.control-label{ :for => "discoverability" } Discoverability
         .controls
           %input{ :type => 'number', :min => '1', :max => '10', :name => 'discoverability', :value => "#{@finding.discoverability}", :required => true}
     - elsif @cvss
       .control-group
-        %label{ :class => "control-label", :for => "attack_vector" }
+        %label.control-label{ :for => "attack_vector" }
           %a{:href=> '#mymodal', "data-toggle"=>'modal', :class=>'btn btn-info'}
             CVSS Vector String
         .controls
@@ -415,7 +415,7 @@
                 updateDropdown(this.value);
                 });
       .control-group
-        %label{ :class => "control-label", :for => "av" } Access Vector
+        %label.control-label{ :for => "av" } Access Vector
         .controls
           %select{ :name => "av", :id => "av" }
             - options.av.each do |av|
@@ -424,7 +424,7 @@
               - else
                 %option #{av}
       .control-group
-        %label{ :class => "control-label", :for => "ac" } Access Complexity
+        %label.control-label{ :for => "ac" } Access Complexity
         .controls
           %select{ :name => "ac", :id => "ac" }
             - options.ac.each do |ac|
@@ -433,7 +433,7 @@
               - else
                 %option #{ac}
       .control-group
-        %label{ :class => "control-label", :for => "au" } Authentication
+        %label.control-label{ :for => "au" } Authentication
         .controls
           %select{ :name => "au", :id => "au" }
             - options.au.each do |au|
@@ -442,7 +442,7 @@
               - else
                 %option #{au}
       .control-group
-        %label{ :class => "control-label", :for => "c" } Confidentiality Impact
+        %label.control-label{ :for => "c" } Confidentiality Impact
         .controls
           %select{ :name => "c", :id => "c" }
             - options.c.each do |c|
@@ -451,7 +451,7 @@
               - else
                 %option #{c}
       .control-group
-        %label{ :class => "control-label", :for => "i" } Integrity Impact
+        %label.control-label{ :for => "i" } Integrity Impact
         .controls
           %select{ :name => "i", :id => "i" }
             - options.i.each do |i|
@@ -460,7 +460,7 @@
               - else
                 %option #{i}
       .control-group
-        %label{ :class => "control-label", :for => "a" } Availability Impact
+        %label.control-label{ :for => "a" } Availability Impact
         .controls
           %select{ :name => "a", :id => "a" }
             - options.a.each do |a|
@@ -469,7 +469,7 @@
               - else
                 %option #{a}
       .control-group
-        %label{ :class => "control-label", :for => "e" } Exploitability
+        %label.control-label{ :for => "e" } Exploitability
         .controls
           %select{ :name => "e", :id => "e" }
             - options.e.each do |e|
@@ -478,7 +478,7 @@
               - else
                 %option #{e}
       .control-group
-        %label{ :class => "control-label", :for => "rl" } Remediation Level
+        %label.control-label{ :for => "rl" } Remediation Level
         .controls
           %select{ :name => "rl", :id => "rl" }
             - options.rl.each do |rl|
@@ -487,7 +487,7 @@
               - else
                 %option #{rl}
       .control-group
-        %label{ :class => "control-label", :for => "rc" } Report Confidence
+        %label.control-label{ :for => "rc" } Report Confidence
         .controls
           %select{ :name => "rc", :id => "rc" }
             - options.rc.each do |rc|
@@ -496,7 +496,7 @@
               - else
                 %option #{rc}
       .control-group
-        %label{ :class => "control-label", :for => "cdp" } Collateral Damage Potential
+        %label.control-label{ :for => "cdp" } Collateral Damage Potential
         .controls
           %select{ :name => "cdp", :id => "cdp" }
             - options.cdp.each do |cdp|
@@ -505,7 +505,7 @@
               - else
                 %option #{cdp}
       .control-group
-        %label{ :class => "control-label", :for => "td" } Target Distribution
+        %label.control-label{ :for => "td" } Target Distribution
         .controls
           %select{ :name => "td", :id => "td" }
             - options.td.each do |td|
@@ -514,7 +514,7 @@
               - else
                 %option #{td}
       .control-group
-        %label{ :class => "control-label", :for => "cr" } Confidentiality Requirement
+        %label.control-label{ :for => "cr" } Confidentiality Requirement
         .controls
           %select{ :name => "cr", :id => "cr" }
             - options.cr.each do |cr|
@@ -523,7 +523,7 @@
               - else
                 %option #{cr}
       .control-group
-        %label{ :class => "control-label", :for => "ir" } Integrity Requirement
+        %label.control-label{ :for => "ir" } Integrity Requirement
         .controls
           %select{ :name => "ir", :id => "ir" }
             - options.ir.each do |ir|
@@ -532,7 +532,7 @@
               - else
                 %option #{ir}
       .control-group
-        %label{ :class => "control-label", :for => "ar" } Availability Requirement
+        %label.control-label{ :for => "ar" } Availability Requirement
         .controls
           %select{ :name => "ar", :id => "ar" }
             - options.ar.each do |ar|
@@ -542,39 +542,39 @@
                 %option #{ar}
     - elsif @cvssv3
       .control-group.cvss3
-        %label{ :class => "control-label", :for => "attack_vector" }
-          %a{:href=> '#mymodal', "data-toggle"=>'modal', :class=>'btn btn-info'}
+        %label.control-label{ :for => "attack_vector" }
+          %a.btn.btn-info{:href=> "#mymodal", "data-toggle"=>'modal', :class=>'btn btn-info'}
             CVSS Vector String
         .controls
-          %input{:type => "text", :class=>"form-control", :placeholder=>"CVSS Vector String", :id=>"vs", :style=>"width:35em"}
-        .modal{:id=>'mymodal', :class=>'modal hide fade', :tabindex=>'-1', :role=>'dialog', "aria-labelledby"=>'modal-label', "aria-hidden"=>'true'}
+          %input.form-control#vs{ :type => "text", :placeholder=>"CVSS Vector String", :style=>"width:35em" }
+        .modal.modal.hide.fade#mymodal{ :tabindex => "-1", :role => "dialog", "aria-labelledby" => "modal-label", "aria-hidden" => "true"}
           .modal-header
-            %button{:type=>'button', :class=>'close', "data-dismiss"=>"modal", "aria-hidden"=>"true"}
+            %button.close{ :type => "button", "data-dismiss" => "modal", "aria-hidden" => "true" }
               x
-            %h3{:id=>"modal-label"}
+            %h3#modal-label
               CVSS Vector String
           .modal-body
-            %link{ :rel=>"stylesheet", :type=>"text/css", :media=>"all", :href=>"/css/cvss.css"}
+            %link{ :rel => "stylesheet", :type => "text/css", :media => "all", :href => "/css/cvss.css" }
             %script{:src => "/js/cvsscalc30.js"}
             %script{ :src => "/js/cvss3.js"}
-            %div{ :id=>"cvssboard"}
-      %span{:class=>"input-group-btn"}
+            %div#cvssboard
+      %span.input-group-btn
       .control-group.cvss3
-        %label{ :class => "control-label", :for => "attack_vector" } Base Score
+        %label.control-label{ :for => "attack_vector" } Base Score
         .controls
           #baseScore.cvssjs
             .results
               %span.score
               %span.severity
       .control-group.cvss3
-        %label{ :class => "control-label", :for => "attack_vector" } Temporal Score
+        %label.control-label{ :for => "attack_vector" } Temporal Score
         .controls
           #temporalScore.cvssjs
             .results
               %span.score
               %span.severity
       .control-group.cvss3
-        %label{ :class => "control-label", :for => "attack_vector" } Environmental Score
+        %label.control-label{ :for => "attack_vector" } Environmental Score
         .controls
           #environmentalScore.cvssjs
             .results
@@ -582,7 +582,7 @@
               %span.severity
 
       .control-group.cvss3
-        %label{ :class => "control-label", :for => "attack_vector" } Attack Vector
+        %label.control-label{ :for => "attack_vector" } Attack Vector
         .controls
           %select{ :name => "attack_vector", :id => "attack_vector", "data-cvss-tag" => "AV"  }
             - options.attack_vector.each do |attack_vector|
@@ -591,189 +591,189 @@
               - else
                 %option #{attack_vector}
       .control-group.cvss3
-        %label{ :class => "control-label", :for => "attack_complexity" } Attack Complexity
+        %label.control-label{ :for => "attack_complexity" } Attack Complexity
         .controls
-          %select{ :name => "attack_complexity", :id =>  "attack_complexity", "data-cvss-tag" => "AC" }
+          %select#attack_complexity{ :name => "attack_complexity", "data-cvss-tag" => "AC" }
             - options.attack_complexity.each do |attack_complexity|
               - if attack_complexity == @finding.attack_complexity
                 %option{ :selected => "selected" } #{attack_complexity}
               - else
                 %option #{attack_complexity}
       .control-group.cvss3
-        %label{ :class => "control-label", :for => "privileges_required" } Privileges Required
+        %label.control-label{ :for => "privileges_required" } Privileges Required
         .controls
-          %select{ :name => "privileges_required", :id =>  "privileges_required", "data-cvss-tag" => "PR" }
+          %select#privileges_required{ :name => "privileges_required", "data-cvss-tag" => "PR" }
             - options.privileges_required.each do |privileges_required|
               - if privileges_required == @finding.privileges_required
                 %option{ :selected => "selected" } #{privileges_required}
               - else
                 %option #{privileges_required}
       .control-group.cvss3
-        %label{ :class => "control-label", :for => "user_interaction" } User Interaction
+        %label.control-label{ :for => "user_interaction" } User Interaction
         .controls
-          %select{ :name => "user_interaction", :id => "user_interaction", "data-cvss-tag" => "UI"  }
+          %select#user_interaction{ :name => "user_interaction", "data-cvss-tag" => "UI" }
             - options.user_interaction.each do |user_interaction|
               - if user_interaction == @finding.user_interaction
                 %option{ :selected => "selected" } #{user_interaction}
               - else
                 %option #{user_interaction}
       .control-group.cvss3
-        %label{ :class => "control-label", :for => "scope_cvss" } Scope
+        %label.control-label{ :for => "scope_cvss" } Scope
         .controls
-          %select{ :name => "scope_cvss", :id => "scope", "data-cvss-tag" => "S"  }
+          %select#scope{ :name => "scope_cvss", "data-cvss-tag" => "S"  }
             - options.scope_cvss.each do |scope_cvss|
               - if scope_cvss == @finding.scope_cvss
                 %option{ :selected => "selected" } #{scope_cvss}
               - else
                 %option #{scope_cvss}
       .control-group.cvss3
-        %label{ :class => "control-label", :for => "confidentiality" } Confidentiality
+        %label.control-label{ :for => "confidentiality" } Confidentiality
         .controls
-          %select{ :name => "confidentiality", :id => "confidentiality-impact", "data-cvss-tag" => "C" }
+          %select#confidentiality-impact{ :name => "confidentiality", "data-cvss-tag" => "C" }
             - options.confidentiality.each do |confidentiality|
               - if confidentiality == @finding.confidentiality
                 %option{ :selected => "selected" } #{confidentiality}
               - else
                 %option #{confidentiality}
       .control-group.cvss3
-        %label{ :class => "control-label", :for => "integrity" } Integrity
+        %label.control-label{ :for => "integrity" } Integrity
         .controls
-          %select{ :name => "integrity", :id => "integrity", "data-cvss-tag" => "I" }
+          %select#integrity{ :name => "integrity", "data-cvss-tag" => "I" }
             - options.integrity.each do |integrity|
               - if integrity == @finding.integrity
                 %option{ :selected => "selected" } #{integrity}
               - else
                 %option #{integrity}
       .control-group.cvss3
-        %label{ :class => "control-label", :for => "availability" } Availability
+        %label.control-label{ :for => "availability" } Availability
         .controls
-          %select{ :name => "availability", :id => "availability", "data-cvss-tag" => "A" }
+          %select#availability{ :name => "availability", "data-cvss-tag" => "A" }
             - options.availability.each do |availability|
               - if availability == @finding.availability
                 %option{ :selected => "selected" } #{availability}
               - else
                 %option #{availability}
       .control-group.cvss3
-        %label{ :class => "control-label", :for => "exploit_maturity" } Exploit Code Maturity
+        %label.control-label{ :for => "exploit_maturity" } Exploit Code Maturity
         .controls
-          %select{ :name => "exploit_maturity", :id => "exploit_maturity", "data-cvss-tag" => "E"  }
+          %select#exploit_maturity{ :name => "exploit_maturity", "data-cvss-tag" => "E"  }
             - options.exploit_maturity.each do |exploit_maturity|
               - if exploit_maturity == @finding.exploit_maturity
                 %option{ :selected => "selected" } #{exploit_maturity}
               - else
                 %option #{exploit_maturity}
       .control-group.cvss3
-        %label{ :class => "control-label", :for => "remeditation_level" } Remediation Level
+        %label.control-label{ :for => "remeditation_level" } Remediation Level
         .controls
-          %select{ :name => "remeditation_level", :id => "remeditation_level", "data-cvss-tag" => "RL" }
+          %select#remeditation_level{ :name => "remeditation_level", "data-cvss-tag" => "RL" }
             - options.remeditation_level.each do |remeditation_level|
               - if remeditation_level == @finding.remeditation_level
                 %option{ :selected => "selected" } #{remeditation_level}
               - else
                 %option #{remeditation_level}
       .control-group.cvss3
-        %label{ :class => "control-label", :for => "report_confidence" } Report Confidence
+        %label.control-label{ :for => "report_confidence" } Report Confidence
         .controls
-          %select{ :name => "report_confidence", :id => "report_confidence", "data-cvss-tag" => "RC" }
+          %select#report_confidence{ :name => "report_confidence", "data-cvss-tag" => "RC" }
             - options.report_confidence.each do |report_confidence|
               - if report_confidence == @finding.report_confidence
                 %option{ :selected => "selected" } #{report_confidence}
               - else
                 %option #{report_confidence}
       .control-group.cvss3
-        %label{ :class => "control-label", :for => "confidentiality_requirement" } Confidentiality Requirement
+        %label.control-label{ :for => "confidentiality_requirement" } Confidentiality Requirement
         .controls
-          %select{ :name => "confidentiality_requirement", :id => "confidentiality_requirement", "data-cvss-tag" => "CR" }
+          %select#confidentiality_requirement{ :name => "confidentiality_requirement", "data-cvss-tag" => "CR" }
             - options.confidentiality_requirement.each do |confidentiality_requirement|
               - if confidentiality_requirement == @finding.confidentiality_requirement
                 %option{ :selected => "selected" } #{confidentiality_requirement}
               - else
                 %option #{confidentiality_requirement}
       .control-group.cvss3
-        %label{ :class => "control-label", :for => "integrity_requirement" } Integrity Requirement
+        %label.control-label{ :for => "integrity_requirement" } Integrity Requirement
         .controls
-          %select{ :name => "integrity_requirement", :id => "integrity_requirement", "data-cvss-tag" => "IR" }
+          %select#integrity_requirement{ :name => "integrity_requirement", "data-cvss-tag" => "IR" }
             - options.integrity_requirement.each do |integrity_requirement|
               - if integrity_requirement == @finding.integrity_requirement
                 %option{ :selected => "selected" } #{integrity_requirement}
               - else
                 %option #{integrity_requirement}
       .control-group.cvss3
-        %label{ :class => "control-label", :for => "availability_requirement" } Availability Requirement
+        %label.control-label{ :for => "availability_requirement" } Availability Requirement
         .controls
-          %select{ :name => "availability_requirement", :id => "availability_requirement", "data-cvss-tag" => "AR" }
+          %select#availability_requirement{ :name => "availability_requirement", "data-cvss-tag" => "AR" }
             - options.availability_requirement.each do |availability_requirement|
               - if availability_requirement == @finding.availability_requirement
                 %option{ :selected => "selected" } #{availability_requirement}
               - else
                 %option #{availability_requirement}
       .control-group.cvss3
-        %label{ :class => "control-label", :for => "mod_attack_vector" } Modified Attack Vector
+        %label.control-label{ :for => "mod_attack_vector" } Modified Attack Vector
         .controls
-          %select{ :name => "mod_attack_vector", :id => "mod_attack_vector", "data-cvss-tag" => "MAV" }
+          %select#mod_attack_vector{ :name => "mod_attack_vector", "data-cvss-tag" => "MAV" }
             - options.mod_attack_vector.each do |mod_attack_vector|
               - if mod_attack_vector == @finding.mod_attack_vector
                 %option{ :selected => "selected" } #{mod_attack_vector}
               - else
                 %option #{mod_attack_vector}
       .control-group.cvss3
-        %label{ :class => "control-label", :for => "mod_attack_complexity" } Modified Attack Complexity
+        %label.control-label{ :for => "mod_attack_complexity" } Modified Attack Complexity
         .controls
-          %select{ :name => "mod_attack_complexity", :id => "mod_attack_complexity", "data-cvss-tag" => "MAC" }
+          %select#mod_attack_complexity{ :name => "mod_attack_complexity", "data-cvss-tag" => "MAC" }
             - options.mod_attack_complexity.each do |mod_attack_complexity|
               - if mod_attack_complexity == @finding.mod_attack_complexity
                 %option{ :selected => "selected" } #{mod_attack_complexity}
               - else
                 %option #{mod_attack_complexity}
       .control-group.cvss3
-        %label{ :class => "control-label", :for => "mod_privileges_required" } Modified Privileges Required
+        %label.control-label{ :for => "mod_privileges_required" } Modified Privileges Required
         .controls
-          %select{ :name => "mod_privileges_required", :id => "mod_privileges_required", "data-cvss-tag" => "MPR" }
+          %select#mod_privileges_required{ :name => "mod_privileges_required", "data-cvss-tag" => "MPR" }
             - options.mod_privileges_required.each do |mod_privileges_required|
               - if mod_privileges_required == @finding.mod_privileges_required
                 %option{ :selected => "selected" } #{mod_privileges_required}
               - else
                 %option #{mod_privileges_required}
       .control-group.cvss3
-        %label{ :class => "control-label", :for => "mod_user_interaction" } Modified User Interaction
+        %label.control-label{ :for => "mod_user_interaction" } Modified User Interaction
         .controls
-          %select{ :name => "mod_user_interaction", :id => "mod_user_interaction", "data-cvss-tag" => "MUI" }
+          %select#mod_user_interaction{ :name => "mod_user_interaction", "data-cvss-tag" => "MUI" }
             - options.mod_user_interaction.each do |mod_user_interaction|
               - if mod_user_interaction == @finding.mod_user_interaction
                 %option{ :selected => "selected" } #{mod_user_interaction}
               - else
                 %option #{mod_user_interaction}
       .control-group.cvss3
-        %label{ :class => "control-label", :for => "mod_scope" } Modified Scope
+        %label.control-label{ :for => "mod_scope" } Modified Scope
         .controls
-          %select{ :name => "mod_scope", :id => "mod_scope", "data-cvss-tag" => "MS" }
+          %select#mod_scope{ :name => "mod_scope", "data-cvss-tag" => "MS" }
             - options.mod_scope.each do |mod_scope|
               - if mod_scope == @finding.mod_scope
                 %option{ :selected => "selected" } #{mod_scope}
               - else
                 %option #{mod_scope}
       .control-group.cvss3
-        %label{ :class => "control-label", :for => "mod_confidentiality" } Modified Confidentiality
+        %label.control-label{ :for => "mod_confidentiality" } Modified Confidentiality
         .controls
-          %select{ :name => "mod_confidentiality", :id => "mod_confidentiality", "data-cvss-tag" => "MC" }
+          %select#mod_confidentiality{ :name => "mod_confidentiality", "data-cvss-tag" => "MC" }
             - options.mod_confidentiality.each do |mod_confidentiality|
               - if mod_confidentiality == @finding.mod_confidentiality
                 %option{ :selected => "selected" } #{mod_confidentiality}
               - else
                 %option #{mod_confidentiality}
       .control-group.cvss3
-        %label{ :class => "control-label", :for => "mod_integrity" } Modified Integrity
+        %label.control-label{ :for => "mod_integrity" } Modified Integrity
         .controls
-          %select{ :name => "mod_integrity", :id => "mod_integrity", "data-cvss-tag" => "MI" }
+          %select#mod_integrity{ :name => "mod_integrity", "data-cvss-tag" => "MI" }
             - options.mod_integrity.each do |mod_integrity|
               - if mod_integrity == @finding.mod_integrity
                 %option{ :selected => "selected" } #{mod_integrity}
               - else
                 %option #{mod_integrity}
       .control-group.cvss3
-        %label{ :class => "control-label", :for => "mod_availability" } Modified Availability
+        %label.control-label{ :for => "mod_availability" } Modified Availability
         .controls
-          %select{ :name => "mod_availability", :id => "mod_availability", "data-cvss-tag" => "MA" }
+          %select#mod_availability{ :name => "mod_availability", "data-cvss-tag" => "MA" }
             - options.mod_availability.each do |mod_availability|
               - if mod_availability == @finding.mod_availability
                 %option{ :selected => "selected" } #{mod_availability}
@@ -781,7 +781,7 @@
                 %option #{mod_availability}
     - elsif @riskmatrix
       .control-group
-        %label{ :class => "control-label", :for => "risk" } Vulnerability Risk Level
+        %label.control-label{ :for => "risk" } Vulnerability Risk Level
         .controls
           %select{ :name => "risk" }
             - risk_types = ["None", "Low", "Moderate", "High", "Critical"]
@@ -794,7 +794,7 @@
               - else
                 %option{ :value => "#{r_type}"} #{risk_types[r_type]}
       .control-group
-        %label{ :class => "control-label", :for => "severity" } Severity
+        %label.control-label{ :for => "severity" } Severity
         .controls
           %select{ :name => "severity" }
             - options.severity.each do |severity|
@@ -803,14 +803,14 @@
               - else
                 %option #{severity}
       .control-group
-        %label{ :class => "control-label", :for => "severity_rationale" } Severity Rationale
+        %label.control-label{ :for => "severity_rationale" } Severity Rationale
         .controls
           %textarea{ :rows => '3', :class => 'input-xxlarge allowMarkupShortcut', :id => 'severity_rationale', :name => 'severity_rationale'}
             - if @finding
               - if @finding.severity_rationale
                 #{meta_markup(@finding.severity_rationale)}
       .control-group
-        %label{ :class => "control-label", :for => "likelihood" } Likelihood
+        %label.control-label{ :for => "likelihood" } Likelihood
         .controls
           %select{ :name => "likelihood" }
             - options.likelihood.each do |likelihood|
@@ -819,7 +819,7 @@
               - else
                 %option #{likelihood}
       .control-group
-        %label{ :class => "control-label", :for => "likelihood_rationale" } Likelihood Rationale
+        %label.control-label{ :for => "likelihood_rationale" } Likelihood Rationale
         .controls
           %textarea{ :rows => '3', :class => 'input-xxlarge allowMarkupShortcut', :id => 'likelihood_rationale', :name => 'likelihood_rationale'}
             - if @finding
@@ -827,7 +827,7 @@
                 #{meta_markup(@finding.likelihood_rationale)}
     - else
       .control-group
-        %label{ :class => "control-label", :for => "risk" } Vulnerability Risk Level
+        %label.control-label{ :for => "risk" } Vulnerability Risk Level
         .controls
           %select{ :name => "risk" }
             - risk_types = ["Informational", "Low", "Moderate", "High", "Critical"]
@@ -840,7 +840,7 @@
               - else
                 %option{ :value => "#{r_type}"} #{risk_types[r_type]}
     .control-group
-      %label{ :class => "control-label", :for => "effort" } Remediation Effort
+      %label.control-label{ :for => "effort" } Remediation Effort
       .controls
         %select{ :name => "effort" }
           - options.effort.each do |effort|
@@ -849,7 +849,7 @@
             - else
               %option #{effort}
     .control-group
-      %label{ :class => "control-label", :for => "type" } Finding Type
+      %label.control-label{ :for => "type" } Finding Type
       .controls
         %select{ :name => "type" }
           - options.finding_types.each do |type|
@@ -858,7 +858,7 @@
             - else
               %option #{type}
     .control-group
-      %label{ :class => "control-label", :for => "overview" }
+      %label.control-label{ :for => "overview" }
         %a{:href=> '#modaloverview', "data-toggle"=>'modal', :class=>'btn btn-info'}
           Overview
       .modal{:id=>'modaloverview', :class=>'modal hide fade', :tabindex=>'-1', :role=>'dialog', "aria-labelledby"=>'modal-label', "aria-hidden"=>'true'}
@@ -935,7 +935,7 @@
             - if @finding.overview
               #{meta_markup(@finding.overview)}
     .control-group
-      %label{ :class => "control-label", :for => "pocu" } Proof of Concept
+      %label.control-label{ :for => "pocu" } Proof of Concept
       .controls
         %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :name => 'poc', :id => "pocu"}
           - if @finding
@@ -966,21 +966,21 @@
 
     - if !@master
       .control-group
-        %label{ :class => "control-label", :for => "affected_hosts" } Affected Hosts/URLs
+        %label.control-label{ :for => "affected_hosts" } Affected Hosts/URLs
         .controls
           %textarea{ :rows => '3', :class => 'input-xxlarge allowMarkupShortcut', :name => 'affected_hosts'}
             - if @finding
               - if @finding.affected_hosts
                 #{meta_markup(@finding.affected_hosts)}
     .control-group
-      %label{ :class => "control-label", :for => "remediation" } Remediation
+      %label.control-label{ :for => "remediation" } Remediation
       .controls
         %textarea{ :rows => '10', :class => 'input-xxlarge allowMarkupShortcut', :name => 'remediation'}
           - if @finding
             - if @finding.remediation
               #{meta_markup(@finding.remediation)}
     .control-group
-      %label{ :class => "control-label", :for => "references" } References (One Per Line)
+      %label.control-label{ :for => "references" } References (One Per Line)
       .controls
         %textarea{ :rows => '5', :class => 'input-xxlarge allowMarkupShortcut', :name => 'references'}
           - if @finding
@@ -988,7 +988,7 @@
               #{meta_markup(@finding.references)}
     - if !@master
       .control-group
-        %label{ :class => "control-label", :for => "notes" } Notes Data
+        %label.control-label{ :for => "notes" } Notes Data
         %i{:class=>"icon-chevron-down", "data-toggle"=>"collapse", "data-target"=>"#info_2", :id=>"actionButton"}
         .info{ :id => "info_2", :class => "collapse out" }
           %label
@@ -1000,7 +1000,7 @@
                 #{meta_markup(@finding.notes)}
     - if !@master
       .control-group
-        %label{ :class => "control-label", :for => "preso" } Presentation Data
+        %label.control-label{ :for => "preso" } Presentation Data
         %i{:class=>"icon-chevron-down", "data-toggle"=>"collapse", "data-target"=>"#info_1", :id=>"actionButton"}
         .info{ :id => "info_1", :class => "collapse out" }
           %label
@@ -1050,9 +1050,7 @@
     }
 
     function updateCVSSSummary(updateCVSSJS) {
-      var vectorString = "";
-
-      vectorString = "CVSS:3.0";
+      var vectorString = "CVSS:3.0";
 
       $("select[data-cvss-tag]").each(function (index, element) {
         if (element.value.toLowerCase() == "not defined") {


### PR DESCRIPTION
I made 2 or 3 changes related to the behavior of the CVSS creation / edition pages.

First, I displayed a CVSS Summary that is being updated when you change the metrics in the page. Our team had to work with CVSS and every single member of the team wished we had the numeral values displayed on the page to gauge severity as we go. This eases the transition from risk based or DREAD to CVSS.
![image](https://user-images.githubusercontent.com/3847037/31297583-96b0d158-aab4-11e7-8f3c-7c9d90cadce9.png)

I have also synchronized the dropdown in the page with the CVSS modal window. The modal updated the dropdown when closed, but the dropdown did not update the content of the modal when changed. This was a bit frustrating when changing from one to the other.

The last this I did was to cleanup the "findings_edit" and "create_finding" pages. I have simplified the CVSS modal handling javascript code and made the .haml format more uniform. Sometimes tags were written as `%div.class#id{ "double_quotes" => 'single_quotes' }` while other times it was `%div{ :class => "class", :id => "id", "double_quotes" => "single_quotes" }`. The lack of uniformity caused problems like having two different ids on an element or code duplication.