### PR TITLE
Fixed the other search forms (related to #402)

### DIFF
--- a/public/js/helpers.js
+++ b/public/js/helpers.js
@@ -1,4 +1,31 @@
-//used to confirm deletion
+// Used to search in tables
+// credit to http://www.redotheweb.com/2013/05/15/client-side-full-text-search-in-css.html for this
+function initSearch() {
+  var searchBox = document.getElementById('search');
+  var searchStyle = document.getElementById('search_style');
+
+  if (searchBox && searchStyle) {
+    // If the page loads with a value already present in the tables,
+    // lets run the search right away
+    if (searchBox.value) {
+      searchStyle.innerHTML = ".searchable:not([data-index*=\"" + searchBox.value.toLowerCase().replace(/</g, '&lt;').replace(/>/g, '&rt;').replace(/"/g, '&quot;') + "\"]) { display: none; }";
+    }
+
+    searchBox.addEventListener('input', function() {
+      if (!this.value) {
+        searchStyle.innerHTML = "";
+        return;
+      }
+      searchStyle.innerHTML = ".searchable:not([data-index*=\"" + this.value.toLowerCase().replace(/</g, '&lt;').replace(/>/g, '&rt;').replace(/"/g, '&quot;') + "\"]) { display: none; }";
+    });
+  }
+}
+
+$(document).ready(function(){
+  initSearch();
+});
+
+// Used to confirm deletion
 function confirmDelete(evt) {
   if (!confirm('Are you sure you want to permanently delete the selected element(s) ?')) {
     evt.preventDefault();

--- a/views/findings_add.haml
+++ b/views/findings_add.haml
@@ -45,7 +45,7 @@
                         - @findings.each do |finding|
                           - if finding.type == type
                             %tr
-                              %td.searchable{ :style => "width: 80%", :"data-index" => "#{finding.title.downcase.gsub(' ','')}" }
+                              %td.searchable{ :style => "width: 80%", :"data-index" => "#{finding.title.downcase}" }
                                 - if @autoadd
                                   - if @autoadd_findings.include?(finding.id.to_s) and not @dup_findings.include?(finding.id)
                                     %input{ :id => "finding_#{finding.id}", :type => "checkbox", :name => "finding[]", :value => "#{finding.id}", :checked => "" }
@@ -69,7 +69,7 @@
                                           .label.label-default #{ip}
                                         - iplist = @autoadd_hosts[x].join(",")
                                         %input{ :type => "hidden", :name => "finding#{finding.id.to_s}", :value => "#{iplist}" }
-                              %td.searchable{ :style => "width: 20%", :"data-index" => "#{finding.title.downcase.gsub(' ','')}" }
+                              %td.searchable{ :style => "width: 20%", :"data-index" => "#{finding.title.downcase}" }
                                 - if @master
                                   %a.btn.btn-warning{ :href => "/master/findings/#{finding.id}/edit" }
                                     %i.icon-pencil.icon-white{ :title => "Edit" }

--- a/views/findings_add.haml
+++ b/views/findings_add.haml
@@ -14,16 +14,6 @@
     %input.form-control#search{ :type => "text", :placeholder => "Finding Name Search" }
     %style#search_style
     %span.input-group-btn
-    %script{ :type => "text/javascript" }
-      // credit to http://www.redotheweb.com/2013/05/15/client-side-full-text-search-in-css.html for this
-      var searchStyle = document.getElementById('search_style');
-      document.getElementById('search').addEventListener('input', function() {
-      if (!this.value) {
-      searchStyle.innerHTML = "";
-      return;
-      }
-      searchStyle.innerHTML = ".searchable:not([data-index*=\"" + this.value.toLowerCase().replace(/</g, '&rt;').replace(/>/g, '&lt;').replace(/"/g, '&quot;') + "\"]) { display: none; }";
-      });
     %form.form-inline{ :method => "post", :action => "/report/#{@report.id}/findings_add" }
       .table
         %table{ :style => "width: 90%" }

--- a/views/findings_list.haml
+++ b/views/findings_list.haml
@@ -33,16 +33,6 @@
             %br
             %style#search_style
             %span.input-group-btn
-            %script{ :type=>"text/javascript" }
-              // credit to http://www.redotheweb.com/2013/05/15/client-side-full-text-search-in-css.html for this
-              var searchStyle = document.getElementById('search_style');
-              document.getElementById('search').addEventListener('input', function() {
-              if (!this.value) {
-              searchStyle.innerHTML = "";
-              return;
-              }
-              searchStyle.innerHTML = ".searchable:not([data-index*=\"" + this.value.toLowerCase().replace(/</g, '&lt;').replace(/>/g, '&rt;').replace(/"/g, '&quot;') + "\"]) { display: none; }";
-              });
             &nbsp;
             - settings.finding_types.each do |type|
               %tr

--- a/views/reports_list.haml
+++ b/views/reports_list.haml
@@ -36,15 +36,15 @@
                 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Actions
             - @reports.each do |report|
               %tr
-                %td.searchable{ :"data-index" => "#{report.report_name.downcase.gsub(' ','')}" }
+                %td.searchable{ :"data-index" => "#{report.report_name.downcase}" }
                   %input.checkbox{ :type => "checkbox", :name => "#{report.id}" }
-                %td.searchable{ :style => "width: 70%", :"data-index" => "#{report.report_name.downcase.gsub(' ','')}" }
+                %td.searchable{ :style => "width: 70%", :"data-index" => "#{report.report_name.downcase}" }
                   #{report.report_name}
-                %td.searchable{ :style => "width: 10%", :"data-index" => "#{report.report_name.downcase.gsub(' ','')}" }
+                %td.searchable{ :style => "width: 10%", :"data-index" => "#{report.report_name.downcase}" }
                   #{report.full_company_name}
-                %td.searchable{ :style => "width: 10%", :"data-index" => "#{report.report_name.downcase.gsub(' ','')}" }
+                %td.searchable{ :style => "width: 10%", :"data-index" => "#{report.report_name.downcase}" }
                   #{report.owner}
-                %td.searchable{ :style => "width: 20%", :"data-index" => "#{report.report_name.downcase.gsub(' ','')}" }
+                %td.searchable{ :style => "width: 20%", :"data-index" => "#{report.report_name.downcase}" }
                   - if @master
                     %a.btn.btn-warning{ :href => "/master/reports/#{finding.id}" }
                       %i.icon-pencil.icon-white{ :title => "Edit" }

--- a/views/reports_list.haml
+++ b/views/reports_list.haml
@@ -7,16 +7,6 @@
             %input.form-control#search{ :type => "text", :placeholder => "Report Name Search" }
             %style#search_style
             %span.input-group-btn
-            %script{ :type=>"text/javascript" }
-              // credit to http://www.redotheweb.com/2013/05/15/client-side-full-text-search-in-css.html for this
-              var searchStyle = document.getElementById('search_style');
-              document.getElementById('search').addEventListener('input', function() {
-              if (!this.value) {
-              searchStyle.innerHTML = "";
-              return;
-              }
-              searchStyle.innerHTML = ".searchable:not([data-index*=\"" + this.value.toLowerCase().replace(/</g, '&lt;').replace(/>/g, '&rt;').replace(/"/g, '&quot;') + "\"]) { display: none; }";
-              });
             %br
             %br
             %a.btn.btn-danger#deletemultiple{ :href => "/report/remove/" }


### PR DESCRIPTION
Hi,

I have removed the `.gsub(' ','')` from the other search functions (Add findings from the findings database and report list).

This is related to issue #402 and commit https://github.com/SerpicoProject/Serpico/commit/28a70a51fa952e9ac59ed51736b47a8cc2bb6020

Thanks.