### PR TITLE
adding some well-formedness check when report is added and generated

### DIFF
--- a/routes/report.rb
+++ b/routes/report.rb
@@ -1388,6 +1388,14 @@ get '/report/:id/generate' do
   end
   #we bring all xml together
   report_xml = "<report>#{@report.to_xml}#{udv}#{findings_xml}#{udo_xml}#{services_xml}#{hosts_xml}</report>"
+  noko_report_xml = Nokogiri::XML(report_xml)
+  #no use to go on with report generation if report XML is malformed
+  if !noko_report_xml.errors.empty?
+    noko_report_xml.errors.each do |error|
+      error = CGI.escapeHTML(error.to_s)
+    end
+    return "<p>The following error(s) were found in report XML file : </p>#{noko_report_xml.errors.join('<br/>')}<p>This is most often because of malformed metamarkup in findings."
+  end
 
   xslt_elem = Xslt.first(:report_type => @report.report_type)
 


### PR DESCRIPTION
Right now, what happens when you include bad xslt syntax in your template is that you won't know it until generating the word. This can be kinda annoying, as we'd wish to know right after upload a new template wether it will work or not.

This pull request makes it so that right after adding or editing a template report, serpico will tell you if it has xslt problem (like wrong xpathes).

Also, this pull request add a check when generating report : if the xml used for xslt transformation isn't correct, it won't generate the report. This way the user won't have to open the word to know if the report generation properly worked, serpico will tell him right after clicking on " generate" .

Here's what happen if you try to upload a template with wrong xslt syntax :
![image](https://user-images.githubusercontent.com/3451172/36912514-359daccc-1e47-11e8-98de-ad55bfe6f8a7.png)

Here's what happen if the XML used for generating the report wasn't well formed :
![image](https://user-images.githubusercontent.com/3451172/36912554-5d07a204-1e47-11e8-9f2a-faae2594446a.png)

