### PR TITLE
fixing encoding problem

### DIFF
--- a/routes/report.rb
+++ b/routes/report.rb
@@ -400,7 +400,8 @@ post '/report/:id/edit' do
   id = params[:id]
 
   data = url_escape_hash(request.POST)
-
+  #preventing values from degenerating with & double encoding
+  data = data.map{ |param,value| [param, value.gsub('&amp;', '&')]}
   @report = get_report(id)
 
   unless @report.update(data)
@@ -1304,7 +1305,7 @@ get '/report/:id/generate' do
     end
   end
   # we bring all xml together
-  report_xml = "<report>#{@report.to_xml}#{udv}#{findings_xml}#{udo_xml}#{services_xml}#{hosts_xml}</report>"
+  report_xml = "<report>#{CGI.unescapeHTML(@report.to_xml)}#{udv}#{findings_xml}#{udo_xml}#{services_xml}#{hosts_xml}</report>"
   noko_report_xml = Nokogiri::XML(report_xml)
   #no use to go on with report generation if report XML is malformed
   if !noko_report_xml.errors.empty?


### PR DESCRIPTION
This PR fix two problems :

# Encoding degenerating

While this issue was fixed for the findings title, serpico was still adding layer of encoding each time you save the report variables containing a special character 

# Special characters inside the docx

Report variables are HTML encoded to prevent XSS, which is good. However, the data is still encoded when injected in the wordML, and more precisely, inside <w:t> tags. 
Thus, when a report variable contains encoded charaters, it will be displayed _as is_ in the resulting docx.

## Exemple

![encoding_pr_-1](https://user-images.githubusercontent.com/3451172/40318069-af5fff4a-5d23-11e8-846a-6c4f69dcf23f.png)

![encoding_pr_0](https://user-images.githubusercontent.com/3451172/40318190-1abc09b4-5d24-11e8-8b93-dab3cfaaa343.png)

In this PR, I unencode the report variables before they're used to generate the final docx. I verified that "<" and ">" are still encoded, to prevent malicious alteration of the WordML

![encoding_pr](https://user-images.githubusercontent.com/3451172/40318132-ed6d92a2-5d23-11e8-8cad-02d5286c2deb.png)

![encoding_pr2](https://user-images.githubusercontent.com/3451172/40318136-f1c55100-5d23-11e8-9299-097bbda7c0a4.png)


