### PR TITLE
Removed the nist800 checkbox from the config page

### DIFF
--- a/views/config.haml
+++ b/views/config.haml
@@ -42,7 +42,7 @@
           - next if k =~ /ssl_key/
           - next if k =~ /log_file/
           - next if k =~ /image_align/
-          - next if k == "cvss" or k == "dread" or k == "cvssv3" or k == "riskmatrix"
+          - next if k == "cvss" or k == "dread" or k == "cvssv3" or k == "riskmatrix" or k == "nist800"
           %tr
             %td
               %label.col-md-3{ :for => "#{k}" }


### PR DESCRIPTION
This is a minor fix to an issue introduced in PR #462

The scoring methods are assigned using the dropdown list found in the config page.
Since the config page is built dynamically, I simply excluded the scoring algorithms from the controls rendered into the page. Otherwise, you will have a field that is displayed, but cannot be edited.