### PR TITLE
bringing xml appendices back

### DIFF
--- a/model/master.rb
+++ b/model/master.rb
@@ -26,7 +26,7 @@ class TemplateFindings
   property :approved, Boolean, required: false, default: true
   property :risk, Integer, required: false
   property :affected_hosts, String, length: 20_000, required: false
-  
+
   # CVSSv2
   property :av, String, required: false
   property :ac, String, required: false
@@ -93,7 +93,7 @@ class TemplateFindings
   property :impact_val, Float, :required => false
   property :likelihood_val, Float, :required => false
   property :nist_rating, String, :required => false
- 
+
   property :language, String, required: false
 end
 
@@ -364,7 +364,7 @@ class Attachments
   property :filename_location, String, length: 400
   property :report_id, String, length: 30
   property :description, String, length: 500
-  property :caption, String, length: 500
+  property :appendice, Boolean
 end
 
 class Charts

--- a/routes/report.rb
+++ b/routes/report.rb
@@ -289,7 +289,7 @@ post '/report/:id/upload_attachments' do
     datax['filename'] = upf[:filename]
     datax['description'] = CGI.escapeHTML(upf[:filename]).tr(' ', '_').tr('/', '_').tr('\\', '_').tr('`', '_')
     datax['report_id'] = id
-    datax['caption'] = params[:caption]
+    datax['appendice'] = params[:appendice]
     data = url_escape_hash(datax)
 
     @attachment = Attachments.new(data)
@@ -1304,8 +1304,21 @@ get '/report/:id/generate' do
       hosts_xml = hosts_xml_raw.doc.root.to_xml
     end
   end
+  # we add the xml from the attachments the user added
+  all_appendices_xml = "<appendices>\n"
+  all_appendices = Attachments.all(report_id: id, appendice: true)
+  all_appendices.each do |appendice|
+    next unless File.file?(appendice.filename_location)
+    # the filename without the extension becomes the xml tag
+    appendice_xml = "<#{appendice.filename.split('.')[0]}>"
+    appendice_xml += Nokogiri::XML(File.open(appendice.filename_location).read).root.to_xml
+    appendice_xml += "</#{appendice.filename.split('.')[0]}>"
+    all_appendices_xml += appendice_xml.to_s
+
+  end
+  all_appendices_xml += "</appendices>\n"
   # we bring all xml together
-  report_xml = "<report>#{CGI.unescapeHTML(@report.to_xml)}#{udv}#{findings_xml}#{udo_xml}#{services_xml}#{hosts_xml}</report>"
+  report_xml = "<report>#{CGI.unescapeHTML(@report.to_xml)}#{udv}#{findings_xml}#{udo_xml}#{services_xml}#{hosts_xml}#{all_appendices_xml}</report>"
   noko_report_xml = Nokogiri::XML(report_xml)
   #no use to go on with report generation if report XML is malformed
   if !noko_report_xml.errors.empty?

--- a/views/upload_attachments.haml
+++ b/views/upload_attachments.haml
@@ -1,22 +1,78 @@
-.col-md-10
-  %br
-  %h2 Upload Attachment
-  %h4 Note:
-  %h4 &nbsp;&nbsp;&bullet;&nbsp;Only jpg and png are supported for screenshots
-  %h4 &nbsp;&nbsp;&bullet;&nbsp;The file name is inherited from the file.
-  %h4 &nbsp;&nbsp;&bullet;&nbsp;Multiple files can be uploaded at once.
-  - if @no_file == "1"
-    You forgot to include a file, silly
-  %br
-
+.span10
   %form{ :method => "post", :enctype => "multipart/form-data" }
+    %br
+    %h2 Upload Attachment
+    %br
+    .control-group
+      %label{ :class => "control-label", :for => "overview" }
+        %a{ :href=> '#modaloverview', "data-toggle"=>'modal', :class=>'btn btn-info' }
+          Uploading Attachment Help
+      .modal{:id=>'modaloverview', :class=>'modal hide fade', :tabindex=>'-1', :role=>'dialog', "aria-labelledby"=>'modal-label', "aria-hidden"=>'true'}
+        .modal-header
+          %button{ :type=>'button', :class=>'close', "data-dismiss"=>"modal", "aria-hidden"=>"true"}
+            x
+          %h3{ :id=>"modal-label" }
+            Attachments
+        .modal-body
+          %p &bullet;&nbsp;Only jpg and png are supported for screenshots
+          %p &bullet;&nbsp;The file name is inherited from the file.
+          %p &bullet;&nbsp;jpg end png files can be directly inserted into your report template with the metacharacter " ツ "
+          %p &bullet;&nbsp;jpg end png files can be inserted into your findings by using the string " [!!screenshot_name.png!!] "
+          %p &bullet;&nbsp;Multiple files can be uploaded at once.
+          %p &bullet;&nbsp;If an attachment is uploaded as an appendice, the data it contains can be used in your documents template
+          %p
+            %b For now, only XML can be added as an appendice
+          %p
+            For exemple, if you upload a file <b>"recon.xml"</b>, which has a structure like the following :
+          %div{:style => "background-color:#F2F3F4"}
+            %p
+              &lt;host&gt;
+            %p
+              &nbsp;&nbsp;&lt;ip&gt;1.1.1.1&lt;/ip&gt;
+            %p
+              &nbsp;&nbsp;&lt;hostname&gt;www.exemple1.com&lt;/hostname&gt;
+            %p
+              &lt;/host&gt;
+            %p
+              &lt;host&gt;
+            %p
+              &nbsp;&nbsp;&lt;ip&gt;2.2.2.2&gt;&lt;/ip&gt;
+            %p
+              &nbsp;&nbsp;&lt;hostname&gt;www.exemple2.com&lt;/hostname&gt;
+            %p
+              &lt;/host&gt;
+          %p
+            then you could call this data in your document template by doing, for exemple :
+          %div{:style => "background-color:#F2F3F4"}
+            %p
+              ¬report/appendices/&lt;&lt;name_of_your_file_without_extension&gt;&gt;/host¬
+            %p
+              IP : πipπ
+            %p
+              hostname : πhostnameπ
+            %p
+              ∆
+          %p
+            %br
+            This would print in your report all the IP and hostnames contained by report.xml
+
+    - if @no_file == "1"
+      You forgot to include a file, silly
+    %br
     %table
       %tr
         %td
-          %label.col-md-3{ :for => "files" }
-            Upload Files &nbsp;
+          Upload Files &nbsp;
         %td
           %input#files{ :type => "file", :name => "files[]", :multiple => true }
+      %tr
+        %td
+          Appendice
+        %td
+          %input{ :type => 'hidden', :name => 'appendice', :value => "0"}
+          %input{ :type => 'checkbox', :name => 'appendice', :value => "1"}
+
+    %br
     %br
     %input.btn.btn-default{ :type => "submit", :value => "Upload" }
     %a.btn.btn-default{ :href => "/report/#{@report.id}/edit" }


### PR DESCRIPTION
Looks like the XML appendice functionnality was mistakenly deleted (most probably by me).
This PR brings this functionnality back.

See https://github.com/SerpicoProject/Serpico/wiki/Turn-XML-file-into-appendice for an explanation on the functionnality