### PR TITLE
Improve hyperlinks handling

### DIFF
--- a/helpers/helper.rb
+++ b/helpers/helper.rb
@@ -54,23 +54,22 @@ end
 def updateHyperlinks(xmlText)
   retHash = {}
   # Find urls
-  urls = xmlText.scan(/<w:t>{{.*}}<\/w:t>/)
+  urls = xmlText.scan(/<w:t.*>{{.*}}<\/w:t>/)
   # Resources for <Resources> tag
   retHash['urls'] = []
   retHash['id'] = []
-  i = 25
   urls.each do |url|
-    cleanUrl = url.gsub('{{', '').gsub('}}', '').tr(' ', '_')
+    cleanUrl = url.gsub('{{', '').gsub('}}', '').tr(' ', '%20')
     # set resourceId and xmlText
-    resourceId = "r:id=\"rId#{i}\""
+    p_id = "d#{rand(36**7).to_s(36)}"
+    resourceId = "r:id=\"rId#{p_id}\""
     xmlText = xmlText.gsub(url, "<w:hyperlink #{resourceId} w:history=\"1\"><w:r w:rsidRPr=\"00720130\"><w:rPr><w:rStyle w:val=\"Hyperlink\"/></w:rPr>#{cleanUrl}</w:r></w:hyperlink>")
     # remove tags
-    cleanUrl = cleanUrl.gsub('<w:t>', '')
+    cleanUrl = cleanUrl.gsub(/<w:t.*?>/, '')
     cleanUrl = cleanUrl.gsub("<\/w:t>", '')
     # put urls in resources
     retHash['urls'].push(cleanUrl)
-    retHash['id'].push("rId#{i}")
-    i += 1
+    retHash['id'].push("rId#{p_id}")
   end
   retHash['xmlText'] = xmlText
   retHash

--- a/views/report_edit.haml
+++ b/views/report_edit.haml
@@ -39,7 +39,7 @@
                 %label.col-md-3{ :for => "report_name" }
                   Title
               %td{ :style => "width: 70%" }
-                %input#report_name{ :type => "text", :style => "width: 90%", :name => "report_name", :value => "#{@report.report_name}" }
+                %input#report_name{ :type => "text", :style => "width: 90%", :name => "report_name", :value => "#{CGI.unescapeHTML(@report.report_name)}" }
             %tr
               %td{ :style => "width: 30%" }
                 %label.col-md-3{ :for => "assessment_type" }


### PR DESCRIPTION
Hey,

A few changes so that links work even in document with rId tags > 25.
Now, it is also possible to insert hyperlinks in bullet points like this: 
```
*-{{https://example.com}}-*
```

Also a minor update in report_edit.haml to prevent the double encoding of the character **&** in the Title input tags.

Thanks!