### PR TITLE
Multiple Layout Fixes

### DIFF
--- a/routes/admin.rb
+++ b/routes/admin.rb
@@ -647,8 +647,8 @@ post '/admin/udo_templates' do
 
   @udos_templates = UserDefinedObjectTemplates.all
 
-  haml :user_defined_object_templates, encode_html: true
   serpico_log("UDO template added")
+  redirect to('/admin/udo_templates')
 end
 
 # edit udo template

--- a/views/add_user_report.haml
+++ b/views/add_user_report.haml
@@ -19,7 +19,7 @@
                 #{user}
               %td
                 %a.btn.btn-danger{ :href => "/admin/del_user_report/#{@report.id}/#{user}" }
-                  %i.icon-remove.icon-white{ :title => "Remove Author" }
+                  %i.icon-trash.icon-white{ :title => "Remove Author" }
 
     %br
     %label.col-md-3{ :for => "author" }

--- a/views/findings_edit.haml
+++ b/views/findings_edit.haml
@@ -54,7 +54,7 @@
                         #{vuln.msf_ref}
                       %td{ :align => "right" }
                         %a.btn.btn-danger.btn-sm{ :href => "/mapping/#{@finding.id}/vulnmap/#{vuln.id}/delete" }
-                          %i.icon-remove.icon-white.icon-sm{ :value => "#{vuln.msf_ref}", :type => "submit", :title => "Delete" }
+                          %i.icon-trash.icon-white.icon-sm{ :value => "#{vuln.msf_ref}", :type => "submit", :title => "Delete" }
         .control-group
           %label.control-label{ :for => "msf_ref" }
             %a.btn.btn-info{ :href => "#mymodal", "data-toggle" => "modal" }
@@ -110,7 +110,7 @@
                         #{item.pluginid}
                       %td{ :align => "right" }
                         %a.btn.btn-danger.btn-xs{ :href => "/mapping/#{@finding.id}/nessus/#{item.pluginid}/delete" }
-                          %i.icon-remove.icon-white{ :value => "#{item.pluginid}", :type => "submit", :title => "Delete" }
+                          %i.icon-trash.icon-white{ :value => "#{item.pluginid}", :type => "submit", :title => "Delete" }
         .control-group
           %label.control-label{ :for => "nessus_pluginid" } Add new nessus ID mapping
           .controls
@@ -129,7 +129,7 @@
                         #{item.pluginid}
                       %td{ :align => "right" }
                         %a.btn.btn-danger.btn-xs{ :href => "/mapping/#{@finding.id}/burp/#{item.pluginid}/delete" }
-                          %i.icon-remove.icon-white{ :value => "#{item.pluginid}", :type => "submit", :title => "Delete" }
+                          %i.icon-trash.icon-white{ :value => "#{item.pluginid}", :type => "submit", :title => "Delete" }
         .control-group
           %label.control-label{ :for => "burp_pluginid" }
             %a{ :href => "#burpmodal", "data-toggle" => "modal" }
@@ -646,7 +646,7 @@
       -#------------------------- End of add NIST800 ---------------->
 
 
-    - else 
+    - else
       .control-group
         %label.control-label{ :for => "risk" } Vulnerability Risk Level
         .controls

--- a/views/findings_list.haml
+++ b/views/findings_list.haml
@@ -91,7 +91,7 @@
                                     %a.btn.btn-info{ :href => "/master/findings/#{finding.id}/preview" }
                                       %i.icon-play-circle.icon-white{ :title => "Preview" }
                                     %a.btn.btn-danger{ :href => "/master/findings/delete/#{finding.id}" }
-                                      %i.icon-remove.icon-white{ :title => "Delete" }
+                                      %i.icon-trash.icon-white{ :title => "Delete" }
           - else
             :ruby
               vulns = Hash.new 0
@@ -112,7 +112,7 @@
               elsif @nist800
                 @findings.each do |finding|
                   next unless finding
-                  if finding.nist800_total >= 120 
+                  if finding.nist800_total >= 120
                     vulns["critical"] += 1
                   elsif finding.nist800_total >= 80 and finding.nist800_total <= 90
                     vulns["severe"] += 1
@@ -270,7 +270,7 @@
                 - if @dread
                   %td{ :style => "text-align:center" }
                     #{finding.dread_total}
-                  
+
 
                   -#-------------------- display risk score NIST800 in current findings section --------------------#-
                 - elsif @nist800
@@ -304,7 +304,7 @@
                   %a.btn.btn-inverse{ :href => "/report/#{@report.id}/findings/#{finding.id}/upload" }
                     %i.icon-arrow-up.icon-white{ :title => "Add to the findings database" }
                   %a.btn.btn-danger{ :href => "/report/#{@report.id}/findings/remove/#{finding.id}" }
-                    %i.icon-remove.icon-white{ :title => "Delete" }
+                    %i.icon-trash.icon-white{ :title => "Delete" }
             %a.btn.btn-danger#deletemultiple{ :href => "/report/#{@report.id}/findings/remove/" }
               Delete selected
   - else

--- a/views/list_attachments.haml
+++ b/views/list_attachments.haml
@@ -17,7 +17,7 @@
             %th
               Attachment Name
             %th
-              Edit
+              View
             %th
               Delete
           %tbody
@@ -32,7 +32,7 @@
                   %i.icon-play-circle.icon-white{ :title => "Preview" }
               %td
                 %a.btn.btn-danger{ :href => "/report/#{attachment.report_id}/attachments/delete/#{attachment.id}" }
-                  %i.icon-remove.icon-white{ :title => "Preview" }
+                  %i.icon-trash.icon-white{ :title => "Preview" }
 
   - else
     %h3 No Attachments Available.

--- a/views/list_user.haml
+++ b/views/list_user.haml
@@ -23,9 +23,9 @@
               %td{ :style => "width: 30%" }
                 #{user.type} / #{user.auth_type}
               %td{ :style => "width: 40%" }
-                %a.btn.btn-danger{ :href => "/admin/delete/#{user.id}" }
-                  %i.icon-trash.icon-white{ :title => "Delete User" }
                 %a.btn.btn-warning{ :href => "/admin/edit_user/#{user.id}" }
                   %i.icon-pencil.icon-white{ :title => "Edit Password" }
+                %a.btn.btn-danger{ :href => "/admin/delete/#{user.id}" }
+                  %i.icon-trash.icon-white{ :title => "Delete User" }
         - else
           No Users. How Curious. Who are you?

--- a/views/reports_list.haml
+++ b/views/reports_list.haml
@@ -46,7 +46,7 @@
                     %a.btn.btn-info{ :href => "/report/#{report.id}/generate" }
                       %i.icon-play-circle.icon-white{ :title => "Preview" }
                     %a.btn.btn-danger{ :href => "/report/remove/#{report.id}" }
-                      %i.icon-remove.icon-white{ :title => "Delete" }
+                      %i.icon-trash.icon-white{ :title => "Delete" }
                     %a.btn.btn-inverse{ :href => "/admin/add_user/#{report.id}" }
                       %i.icon-user.icon-white{ :title => "Add Author" }
 

--- a/views/template_list.haml
+++ b/views/template_list.haml
@@ -32,10 +32,10 @@
               %td{ :style => "width: 60%" }
                 %a.btn.btn-warning{ :href => "/admin/templates/#{template.id}/edit" }
                   %i.icon-pencil.icon-white{ :title => "Edit" }
-                %a.btn.btn-danger{ :href => "/admin/delete/templates/#{template.id}" }
-                  %i.icon-trash.icon-white{ :title => "Delete Template" }
                 %a.btn.btn-info{ :href => "/admin/templates/#{template.id}/download" }
                   %i.icon-play-circle.icon-white{ :title => "Preview" }
+                %a.btn.btn-danger{ :href => "/admin/delete/templates/#{template.id}" }
+                  %i.icon-trash.icon-white{ :title => "Delete Template" }
                 %a.btn.btn-success{:href => "/admin/templates/#{template.id}/tree"}
                   %i.icon-indent-right.icon-white{:title => 'Tree'}
         - else

--- a/views/user_defined_object_manage.haml
+++ b/views/user_defined_object_manage.haml
@@ -75,10 +75,10 @@
                   %td{ :style => "overflow:hidden;text-overflow:ellipsis;max-width: 300px;" }
                     #{meta_markup(properties[template_property_name.downcase])}
                 %td
-                  %a.btn.btn-danger.btn-small{ :href => "/report/#{@id}/udo/#{udo.id}/delete" }
-                    %i.icon-remove.icon-white{ :title => "Delete this #{udo_template.type.downcase}" }
                   %a.btn.btn-warning.btn-small{ :href => "/report/#{@id}/udo/#{udo.id}/edit" }
                     %i.icon-pencil.icon-white{ :title => "Edit this #{udo_template.type.downcase}" }
+                  %a.btn.btn-danger.btn-small{ :href => "/report/#{@id}/udo/#{udo.id}/delete" }
+                    %i.icon-trash.icon-white{ :title => "Delete this #{udo_template.type.downcase}" }
       - else
         You have no #{udo_template.type.downcase} yet !
         %br

--- a/views/user_defined_object_templates.haml
+++ b/views/user_defined_object_templates.haml
@@ -21,10 +21,10 @@
               %td
                 #{key}
             %td
-              %a.btn.btn-danger.btn-sm{ :href => "/admin/udo_templates?delete=#{udo.id}" }
-                %i.icon-remove.icon-white{ :title => "Delete #{udo.type.downcase} template" }
               %a.btn.btn-warning.btn-sm{ :href => "/admin/udo_template/#{udo.id}/edit" }
                 %i.icon-pencil.icon-white{ :title => "Edit #{udo.type.downcase} template" }
+              %a.btn.btn-danger.btn-sm{ :href => "/admin/udo_templates?delete=#{udo.id}" }
+                %i.icon-trash.icon-white{ :title => "Delete #{udo.type.downcase} template" }
 
   %br
   %br


### PR DESCRIPTION
While working on some other features, I noticed that the layout is not always consistent from one page to the other.

First, I replaced the "Edit" label on the attachment page since this button doesn't allow to edit the attachment.
![image](https://user-images.githubusercontent.com/3847037/45573199-c1456f80-b839-11e8-9904-00bf20e758a2.png)

I also uniformized the delete buttons. Some of the were trash cans, others were X signs. I also moved some buttons around - Some pages had the edit buttons on the left of the trash, others had the edit button on the right.

The last change I did was to fix the admin UDO creation redirection. You were redirected on and empty page. You are now redirected on the UDO admin page.