### PR TITLE
Fixed a crash when you generate a report with a & character in most of the fields

### DIFF
--- a/routes/master.rb
+++ b/routes/master.rb
@@ -64,7 +64,7 @@ post '/master/findings/new' do
   end
 
   # Create NIST800 finding in the main database
-  if(config_options["nist800"]) 
+  if(config_options["nist800"])
     # call nist800 helper function
     data = nist800(data)
   end
@@ -153,8 +153,7 @@ post '/master/findings/:id/edit' do
 
   data['approved'] = data['approved'] == 'on'
 
-  # to prevent title's from degenerating with &gt;, etc. [issue 237]
-  data['title'] = data['title'].gsub('&amp;', '&')
+  data['title'] = data['title']
 
   if config_options['dread']
     data['dread_total'] = data['damage'].to_i + data['reproducability'].to_i + data['exploitability'].to_i + data['affected_users'].to_i + data['discoverability'].to_i
@@ -185,7 +184,7 @@ post '/master/findings/:id/edit' do
   end
 
   # Edit NIST800 finding in the main database
-  if(config_options["nist800"]) 
+  if(config_options["nist800"])
     # call nist800 helper function
     data = nist800(data)
   end

--- a/routes/report.rb
+++ b/routes/report.rb
@@ -459,8 +459,6 @@ post '/report/:id/edit' do
   id = params[:id]
 
   data = url_escape_hash(request.POST)
-  #preventing values from degenerating with & double encoding
-  data = data.map{ |param,value| [param, value.gsub('&amp;', '&')]}
   @report = get_report(id)
 
   unless @report.update(data)
@@ -648,7 +646,7 @@ post '/report/:id/user_defined_variables' do
 
     end
 
-    # TODO are the next few lines ever hit? 
+    # TODO are the next few lines ever hit?
     next unless k =~ /variable_data/
     key = k.split('variable_data_').last.split('_').first.strip
 
@@ -985,8 +983,7 @@ post '/report/:id/findings/:finding_id/edit' do
   return error if error.size > 1
   data = url_escape_hash(request.POST)
 
-  # to prevent title's from degenerating with &gt;, etc. [issue 237]
-  data['title'] = data['title'].gsub('&amp;', '&')
+  data['title'] = data['title']
 
   if @report.scoring.casecmp('dread').zero?
     data['dread_total'] = data['damage'].to_i + data['reproducability'].to_i + data['exploitability'].to_i + data['affected_users'].to_i + data['discoverability'].to_i

--- a/views/findings_edit.haml
+++ b/views/findings_edit.haml
@@ -10,7 +10,7 @@
     .control-group
       %label.control-label{ :for => "title" } Title
       .controls
-        %input{ :type => "text", :name => "title", :value => "#{@finding.title}" }
+        %input{ :type => "text", :name => "title", :value => "#{CGI.unescapeHTML(@finding.title)}" }
     -if !@master
       .control-group
         %label.control-label{ :for => "assessment_type" } Assessment Type

--- a/views/report_edit.haml
+++ b/views/report_edit.haml
@@ -39,7 +39,7 @@
                 %label.col-md-3{ :for => "report_name" }
                   Title
               %td{ :style => "width: 70%" }
-                %input#report_name{ :type => "text", :style => "width: 90%", :name => "report_name", :value => "#{@report.report_name}" }
+                %input#report_name{ :type => "text", :style => "width: 90%", :name => "report_name", :value => "#{CGI.unescapeHTML(@report.report_name)}" }
             %tr
               %td{ :style => "width: 30%" }
                 %label.col-md-3{ :for => "assessment_type" }
@@ -67,31 +67,31 @@
                 %label.col-md-3{ :for => "full_company_name" }
                   Full Company Name
               %td{ :style => "width: 70%" }
-                %input#full_company_name{ :type => "text", :style => "width: 90%", :name => "full_company_name", :value => "#{@report.full_company_name}" }
+                %input#full_company_name{ :type => "text", :style => "width: 90%", :name => "full_company_name", :value => "#{CGI.unescapeHTML(@report.full_company_name)}" }
             %tr
               %td{ :style => "width: 30%" }
                 %label.col-md-3{ :for => "short_company_name" }
                   Short Company Name
               %td{ :style => "width: 70%" }
-                %input#short_company_name{ :type => "text", :style => "width: 90%", :name => "short_company_name", :value => "#{@report.short_company_name}" }
+                %input#short_company_name{ :type => "text", :style => "width: 90%", :name => "short_company_name", :value => "#{CGI.unescapeHTML(@report.short_company_name)}" }
             %tr
               %td{ :style => "width: 30%" }
                 %label.col-md-3{ :for => "company_website" }
                   Company Website
               %td{ :style => "width: 70%" }
-                %input#company_website{ :type => "text", :style => "width: 90%", :name => "company_website", :value => "#{@report.company_website}" }
+                %input#company_website{ :type => "text", :style => "width: 90%", :name => "company_website", :value => "#{CGI.unescapeHTML(@report.company_website)}" }
             %tr
               %td{ :style => "width: 30%" }
                 %label.col-md-3{ :for => "contact_address" }
                   Company Address
               %td{ :style => "width: 70%" }
-                %input#contact_address{ :type => "text", :style => "width: 90%", :name => "contact_address", :value => "#{@report.contact_address}" }
+                %input#contact_address{ :type => "text", :style => "width: 90%", :name => "contact_address", :value => "#{CGI.unescapeHTML(@report.contact_address)}" }
             %tr
               %td{ :style => "width: 30%" }
                 %label.col-md-3{ :for => "contact_city" }
                   Company City
               %td{ :style => "width: 70%" }
-                %input#contact_city{ :type => "text", :style => "width: 90%", :name => "contact_city", :value => "#{@report.contact_city}" }
+                %input#contact_city{ :type => "text", :style => "width: 90%", :name => "contact_city", :value => "#{CGI.unescapeHTML(@report.contact_city)}" }
             %tr
               %td{ :style => "width: 30%" }
                 %label.col-md-3{ :for => "contact_state" }
@@ -109,7 +109,7 @@
                 %label.col-md-3{ :for => "contact_name" }
                   Contact Name
               %td{ :style => "width: 70%" }
-                %input#contact_name{ :type => "text", :style => "width: 90%", :name => "contact_name", :value => "#{@report.contact_name}" }
+                %input#contact_name{ :type => "text", :style => "width: 90%", :name => "contact_name", :value => "#{CGI.unescapeHTML(@report.contact_name)}" }
             %tr
               %td{ :style => "width: 30%" }
                 %label.col-md-3{ :for => "contact_email" }
@@ -121,7 +121,7 @@
                 %label.col-md-3{ :for => "contact_title" }
                   Contact Title
               %td{ :style => "width: 70%" }
-                %input#contact_title{ :type => "text", :style => "width: 90%", :name => "contact_title", :value => "#{@report.contact_title}" }
+                %input#contact_title{ :type => "text", :style => "width: 90%", :name => "contact_title", :value => "#{CGI.unescapeHTML(@report.contact_title)}" }
             %tr
               %td{ :style => "width: 30%" }
                 %label.col-md-3{ :for => "contact_phone" }

--- a/views/report_edit.haml
+++ b/views/report_edit.haml
@@ -97,13 +97,13 @@
                 %label.col-md-3{ :for => "contact_state" }
                   State
               %td{ :style => "width: 70%" }
-                %input#contact_state{ :type => "text", :style => "width: 90%", :name => "contact_state", :value => "#{@report.contact_state}" }
+                %input#contact_state{ :type => "text", :style => "width: 90%", :name => "contact_state", :value => "#{CGI.unescapeHTML(@report.contact_state)}" }
             %tr
               %td{ :style => "width: 30%" }
                 %label.col-md-3{ :for => "contact_zip" }
                   Company Zip
               %td{ :style => "width: 70%" }
-                %input#contact_zip{ :type => "text", :style => "width: 90%", :name => "contact_zip", :value => "#{@report.contact_zip}" }
+                %input#contact_zip{ :type => "text", :style => "width: 90%", :name => "contact_zip", :value => "#{CGI.unescapeHTML(@report.contact_zip)}" }
             %tr
               %td{ :style => "width: 30%" }
                 %label.col-md-3{ :for => "contact_name" }
@@ -115,7 +115,7 @@
                 %label.col-md-3{ :for => "contact_email" }
                   Contact E-Mail
               %td{ :style => "width: 70%" }
-                %input#contact_email{ :type => "email", :style => "width: 90%", :name => "contact_email", :value => "#{@report.contact_email}" }
+                %input#contact_email{ :type => "email", :style => "width: 90%", :name => "contact_email", :value => "#{CGI.unescapeHTML(@report.contact_email)}" }
             %tr
               %td{ :style => "width: 30%" }
                 %label.col-md-3{ :for => "contact_title" }


### PR DESCRIPTION
This issue was caused by the #237 fix. Since the & characters are not escaped when you save, they are rendered as-is in the XML report and it crashed Nokogiri's parser.

![image](https://user-images.githubusercontent.com/3847037/45899367-9fed0200-bdaa-11e8-8e27-f1376cd27824.png)

To fix it, I actually removed the fix that was made for the previous issue. To fix the degeneration of the & signs, I simply HTML decode the value before inserting it into the textbox of the edit page.

The value is encoded everywhere and only decoded in a :value => "" context therefore, this change will fix the encoding problem without (as far as I know) introducing an XSS.