### PR TITLE
Changed the markup example for customer name

### DIFF
--- a/views/create_finding.haml
+++ b/views/create_finding.haml
@@ -498,13 +498,13 @@
             If you place {{ URL }} in any field the text will be hyperlinked, otherwise hyperlinking is ignored.
             %br
           %h2
-            &lt;&lt;CUSTOMER&gt;&gt;
+            &lt;&lt;full_company_name&gt;&gt;
           %p
-            If you place &lt;&lt;CUSTOMER&gt;&gt; in a finding the customer name will be substituted in the finding. This is particularly helpful in the Templated Findings.
+            If you place &lt;&lt;full_company_name&gt;&gt; in a finding the customer name will be substituted in the finding. This is particularly helpful in the Templated Findings.
             %br
             %br
             %code
-              Overall &lt;&lt;CUSTOMER&gt;&gt; was found to have a strong...
+              Overall &lt;&lt;full_company_name&gt;&gt; was found to have a strong...
             %br
             %br
             Will generate the following inside of a report:

--- a/views/findings_edit.haml
+++ b/views/findings_edit.haml
@@ -705,13 +705,13 @@
             If you place {{ URL }} in any field the text will be hyperlinked, otherwise hyperlinking is ignored.
             %br
           %h2
-            &lt;&lt;CUSTOMER&gt;&gt;
+            &lt;&lt;full_company_name&gt;&gt;
           %p
-            If you place &lt;&lt;CUSTOMER&gt;&gt; in a finding the customer name will be substituted in the finding. This is particularly helpful in the Templated Findings.
+            If you place &lt;&lt;full_company_name&gt;&gt; in a finding the customer name will be substituted in the finding. This is particularly helpful in the Templated Findings.
             %br
             %br
             %code
-              Overall &lt;&lt;CUSTOMER&gt;&gt; was found to have a strong...
+              Overall &lt;&lt;full_company_name&gt;&gt; was found to have a strong...
             %br
             %br
             Will generate the following inside of a report:


### PR DESCRIPTION
In the meta markup example popup, there is a section on variable replacement that contains the <<CUSTOMER>> 
![image](https://user-images.githubusercontent.com/3847037/45900474-ea23b280-bdad-11e8-8016-4cf30f77dc10.png)

However, since there is no variable named customer, people using the literal example will end up with <<CUSTOMER>> in their report instead of the actual customer name.

I have replaced the example with full_customer_name to avoid this type of confusion.