### PR TITLE
Added the XSLT code block symbol

### DIFF
--- a/helpers/xslt_generation.rb
+++ b/helpers/xslt_generation.rb
@@ -1013,15 +1013,16 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
     omega = compress(omega)
 
-		replace[count] = "#{CGI::unescapeHTML(omega)}"
-
     # Word puts the XSLT code block into a paragraph node.
     # If we want this to be paragraph agnostic so we can use it in any context (Ex. to change the color of a single
     # table cell) we can use the ⁂! modifier
     # This will remove the <w:p> and </w:p> that are wrapping our code block
     if omega[0] == "!"
       replace[count-1] = replace[count-1][0..replace[count-1].rindex(/<w:p[ >]/)-1]
+  		replace[count] = "#{CGI::unescapeHTML(omega[1..-1])}"
       replace[count+1] = replace[count+1][replace[count+1].index("</w:p>")+"</w:p>".length..-1]
+    else
+  		replace[count] = "#{CGI::unescapeHTML(omega)}"
     end
 
     count = count + 1

--- a/helpers/xslt_generation.rb
+++ b/helpers/xslt_generation.rb
@@ -54,7 +54,7 @@ def locate_error(error, document, position)
 end
 
 def verify_document(document)
-	metacharacters = document.enum_for(:scan,/Ω|§|¬|π|æ|∞|†|µ|ƒ|÷|å|≠|∆|¥|ツ|<\/w:tr>/).map { |b| [Regexp.last_match.begin(0),b] }
+	metacharacters = document.enum_for(:scan,/Ω|§|¬|π|æ|∞|†|µ|ƒ|÷|å|≠|∆|¥|ツ|⁂|<\/w:tr>/).map { |b| [Regexp.last_match.begin(0),b] }
 	i=0
 	buffer = []
 	tree = ""

--- a/helpers/xslt_generation.rb
+++ b/helpers/xslt_generation.rb
@@ -378,6 +378,25 @@ def verify_document(document)
 		  tree.concat("#{tabs}∞#{condition}∞\n")
 		  i = i+1
 
+
+		# ⁂ character
+    # =>  XSLT Code Blocks
+		when "⁂"
+		  tabs = "\t" * buffer.length
+      if (i == metacharacters.length - 1) || (metacharacters[i + 1][1] != '⁂')
+			error = "Error with a ⁂ character : character without pair"
+			tree_valid = false
+			tree.concat("#{tabs}⁂  ←\n")
+			locate_error(error, document, metacharacters[i][0])
+			break
+		  end
+
+		  content = document[metacharacters[i][0]+2..metacharacters[i+1][0]-1].gsub(/<.*?>/,"")
+		  tree.concat("#{tabs}⁂#{content}⁂\n")
+		  i = i+1
+
+
+
 		# end of table
 		when "<\/w:tr>"
 		  if buffer[-1] == "æ"
@@ -974,8 +993,46 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 		document = document.sub('∆',"</w:t></w:r></w:p>#{end_ifs}</xsl:for-each><w:p><w:r><w:t>")
 	end
 
-###############################
-# ツ - Placeholder for image
+
+
+  ###########################
+  # ⁂ - an XSLT block insert
+
+  replace = document.split('⁂')
+
+  if (((replace.size-1) % 2) != 0)
+    raise ReportingError.new("Uneven number of ⁂. This is usually caused by a mismatch in a variable.")
+  end
+
+  count = 0
+  replace.each do |omega|
+    if (count % 2) == 0
+      count = count + 1
+      next
+    end
+
+    omega = compress(omega)
+
+		replace[count] = "#{CGI::unescapeHTML(omega)}"
+
+    # Word puts the XSLT code block into a paragraph node.
+    # If we want this to be paragraph agnostic so we can use it in any context (Ex. to change the color of a single
+    # table cell) we can use the ⁂! modifier
+    # This will remove the <w:p> and </w:p> that are wrapping our code block
+    if omega[0] == "!"
+      replace[count-1] = replace[count-1][0..replace[count-1].rindex(/<w:p[ >]/)-1]
+      replace[count+1] = replace[count+1][replace[count+1].index("</w:p>")+"</w:p>".length..-1]
+    end
+
+    count = count + 1
+  end
+
+  document = replace.join("")
+
+
+
+	###############################
+	# ツ - Placeholder for image
 
 	replace = document.split('ツ')
 


### PR DESCRIPTION
This PR adds a new symbol to the Serpico templating meta-language.

The ⁂ character can be used to add XSLT code blocks.
This is especially useful to do things that would require to create new nodes, change the state of the current node, create complex conditions or XSLT functions, etc.

There are two ways of using this symbol, the `⁂` symbol will insert the code block in the paragraph where it was written. This is useful when you want to add inline code block. An example of this would be when you want to concatenate multiple items into a single sentence.

```
During this engagement, the testers discovered ⁂
<xsl:for-each select="report/findings_list/findings/title">
  <xsl:choose>
    <xsl:when test="position() &lt; last()">
      <xsl:value-of select="concat(., ', ')"/>
    </xsl:when>
    <xsl:otherwise>
      <xsl:value-of select="concat('and ',.)"/>
    </xsl:otherwise>
</xsl:for-each>
⁂. Many of the vulnerabilities were […]
```
![image](https://user-images.githubusercontent.com/3847037/46477793-7d4ee600-c7b9-11e8-99f4-619c1d471db7.png)


The other way of using  the triple star symbol is followed by an exclamation mark `⁂!`. This will remove the paragraph element surrounding the XSLT code block. This is done to bypass Word's behavior of putting everything in paragraph nodes automatically. This is useful to modify the state of an element or to insert new elements like table of contents.

For example, if you put the following code into a cell, you can change the background color of this individual cell according to the value it contains :
![image](https://user-images.githubusercontent.com/3847037/46482831-5b0e9580-c7c4-11e8-8463-bc32f0dba3c8.png)

![image](https://user-images.githubusercontent.com/3847037/46482634-f81cfe80-c7c3-11e8-893a-2c129774dd3b.png)

Do note that this should be considered an advanced feature of the template language and should not be used to replace the other symbols. Using this requires a more advanced comprehension of the XML generated by word if you do not want to crash your template.