### PR TITLE
Update docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ruby:2.3.5
+MAINTAINER Serpico
+
+ENV SRP_ROOT /Serpico
+WORKDIR $SRP_ROOT
+COPY . $SRP_ROOT
+
+RUN bundle install
+
+# Allow DB to be on a shared volume
+VOLUME ["$SRP_ROOT/db"]
+EXPOSE 8443
+
+CMD ["bash", "scripts/docker.sh"]

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby "2.3.3"
+ruby "2.3.5"
 
 gem 'sinatra'
 gem 'haml'

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -29,8 +29,14 @@ external database through `docker-compose` or `docker run -v`.
 ## Running with `docker run`
 
 ```
-# In the foreground
-docker run --rm -p 8443 -v"$(pwd)":/Serpico/db -it serpico
+# Create a new container called "serpico" and run it in the foreground
+docker run --name serpico -p 8443:8443 -v"$(pwd)":/Serpico/db -it serpico
+
+# Stop the container when you no longer need it
+docker stop serpico
+
+# Start it again when you need it. It will keep its state.
+docker start serpico
 ```
 
 This will store the database locally at `$PWD/master.db` Please note that the

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,49 @@
+# Running Inside Docker
+
+The included `Dockerfile` allows to run Serpico inside docker from any system
+that supports containers.
+
+By default, Serpico listens on 8443, you can expose it as `443` if you would
+like by using `docker run -p 443:8443 ...`
+
+The image needs to first be built.
+
+1. Build the image
+2. Map the database location in docker-compose or at `docker run` time.
+3. If the database doesn't exist, it will be created with defaults
+
+## Creating the image
+
+This will create a container with the current state of your repository.
+The database is not created at this point, and this image is safe for
+distribution.
+
+```
+docker build -t serpico .
+```
+
+The Dockerfile exposes a `VOLUME` at `/Serpico/db` to allow mounting an
+external database through `docker-compose` or `docker run -v`.
+
+
+## Running with `docker run`
+
+```
+# In the foreground
+docker run --rm -p 8443 -v"$(pwd)":/Serpico/db -it serpico
+```
+
+This will store the database locally at `$PWD/master.db` Please note that the
+path to the database on the host [must be absolute][1].
+
+[1]: https://docs.docker.com/engine/reference/run/#volume-shared-filesystems
+
+## Caveats
+
+This is a work in progress, so a few things are currently not supported.
+
+- Running a new container with an existing `master.db` will not work because
+  `first_time.rb` will not run, and there won't be any certificates for SSL.
+- `config.json` is not exposed to the host so customization requires rebuilding
+  the image or accessing it with `docker exec bash`.
+

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/bash
+# This script is used as the entry point for the docker image.
+# It will initialize the database if it isn't already present.
+
+if [ ! -f "$SRP_ROOT/db/master.db" ]; then
+    echo "First run detected. Initializing database..."
+    ruby "$SRP_ROOT/scripts/first_time.rb"
+fi
+
+# CMD ["ruby", "serpico.rb"]
+ruby serpico.rb
+


### PR DESCRIPTION
This pull request completely revamps the Dockerfile to use ruby 2.3.5 as requested and simplifies the image building process. It also includes the documentation for building Serpico containers and initial support for decoupling the database file from the container itself.

Currently, it's still missing a way to expose the certificates and configuration outside of the container so that a containerized instance of Serpico can run from an existing database and configuration. If there's enough people interested, I will work on that next.

Cheers,
