### PR TITLE
fix(#441): Removed encode_html from view rendering.

### DIFF
--- a/routes/admin.rb
+++ b/routes/admin.rb
@@ -16,14 +16,14 @@ get '/admin/' do
   redirect to('/no_access') unless is_administrator?
   @admin = true
 
-  haml :admin, encode_html: true
+  haml :admin
 end
 
 get '/admin/add_user' do
   redirect to('/no_access') unless is_administrator?
   @admin = true
 
-  haml :add_user, encode_html: true
+  haml :add_user
 end
 
 # serve a copy of the code
@@ -101,14 +101,14 @@ get '/admin/list_user' do
   @users = User.all
   @plugin = is_plugin?
 
-  haml :list_user, encode_html: true
+  haml :list_user
 end
 
 get '/admin/edit_user/:id' do
   redirect to('/no_access') unless is_administrator?
 
   @user = User.first(id: params[:id])
-  haml :add_user, encode_html: true
+  haml :add_user
 end
 
 get '/admin/delete/:id' do
@@ -133,7 +133,7 @@ get '/admin/add_user/:id' do
 
   @admin = true if is_administrator?
 
-  haml :add_user_report, encode_html: true
+  haml :add_user_report
 end
 
 post '/admin/add_user/:id' do
@@ -198,7 +198,7 @@ get '/admin/config' do
                'default'
              end
 
-  haml :config, encode_html: true
+  haml :config
 end
 
 post '/admin/config' do
@@ -288,7 +288,7 @@ get '/admin/plugins' do
   @admin = true if is_administrator?
   @plugin = true if is_plugin?
 
-  haml :plugins, encode_html: true
+  haml :plugins
 end
 
 # enable plugins
@@ -383,7 +383,7 @@ get '/admin/templates' do
   # Query for all Findings
   @templates = Xslt.all(order: [:report_type.asc])
 
-  haml :template_list, encode_html: true
+  haml :template_list
 end
 
 # Manage Templated Reports
@@ -392,7 +392,7 @@ get '/admin/templates/add' do
 
   @admin = true
 
-  haml :add_template, encode_html: true
+  haml :add_template
 end
 
 # Manage Templated Reports
@@ -447,7 +447,7 @@ post '/admin/templates/add' do
   rescue TemplateVerificationError => detail
     @error_message = CGI::escapeHTML(detail.errorString)
     @tree = CGI::escapeHTML(detail.template_tree)
-    return haml :template_error, encode_html: true
+    return haml :template_error
   rescue ReportingError => detail
     error = true
   end
@@ -500,7 +500,7 @@ post '/admin/templates/add' do
     serpico_log("New report template successfully added")
     redirect to('/admin/templates')
 
-    haml :add_template, encode_html: true
+    haml :add_template
   end
 end
 
@@ -512,7 +512,7 @@ get '/admin/templates/:id/tree' do
   @tree = verify_document(document)
   @tree = @tree[2]
 
-  haml :template_tree, encode_html: true
+  haml :template_tree
 end
 # Manage Templated Reports
 get '/admin/templates/:id/edit' do
@@ -521,7 +521,7 @@ get '/admin/templates/:id/edit' do
   @admin = true
   @template = Xslt.first(id: params[:id])
 
-  haml :edit_template, encode_html: true
+  haml :edit_template
 end
 
 # Manage Templated Reports
@@ -551,7 +551,7 @@ post '/admin/templates/edit' do
   rescue TemplateVerificationError => detail
     @error_message = CGI::escapeHTML(detail.errorString)
     @tree = CGI::escapeHTML(detail.template_tree)
-    return haml :template_error, encode_html: true
+    return haml :template_error
   rescue ReportingError => detail
     error = true
   end
@@ -610,7 +610,7 @@ end
 # get enabled plugins
 get '/admin/admin_plugins' do
   @menu = get_plugin_list('admin')
-  haml :enabled_plugins, encode_html: true
+  haml :enabled_plugins
 end
 
 get '/admin/udo_templates' do
@@ -623,7 +623,7 @@ get '/admin/udo_templates' do
     udo_template.destroy
   end
   @udos_templates = UserDefinedObjectTemplates.all
-  haml :user_defined_object_templates, encode_html: true
+  haml :user_defined_object_templates
 end
 
 post '/admin/udo_templates' do
@@ -657,7 +657,7 @@ get '/admin/udo_template/:template_id/edit' do
   @udo_to_edit = UserDefinedObjectTemplates.get(params[:template_id])
   return 'No such UDO Template' if @udo_to_edit.nil?
   @udo_to_edit_properties = JSON.parse(@udo_to_edit.udo_properties)
-  haml :udo_template_edit, encode_html: true
+  haml :udo_template_edit
 end
 
 post '/admin/udo_template/:template_id/edit' do

--- a/routes/basic.rb
+++ b/routes/basic.rb
@@ -54,7 +54,7 @@ get '/info' do
     @user.save
   end
 
-  haml :info, encode_html: true
+  haml :info
 end
 
 # Save the consultant information into the database
@@ -84,7 +84,7 @@ end
 get '/reset' do
   redirect '/reports/list' unless valid_session?
 
-  haml :reset, encode_html: true
+  haml :reset
 end
 
 # Handles the password reset
@@ -116,7 +116,7 @@ post '/reset' do
   user.update(password: params[:new_pass])
   @message = 'success'
   serpico_log('Password successfully reset')
-  haml :reset, encode_html: true
+  haml :reset
 end
 
 post '/login' do
@@ -168,7 +168,7 @@ get '/logout' do
     sess = Sessions.first(session_key: session[:session_id])
     sess.destroy if sess
   end
-  
+
   serpico_log('User #{user.username} logged out')
   redirect to('/')
 end

--- a/routes/master.rb
+++ b/routes/master.rb
@@ -17,7 +17,7 @@ get '/master/findings' do
   @cvssv3 = config_options['cvssv3']
   @riskmatrix = config_options['riskmatrix']
   @nist800 = config_options['nist800']
-  haml :findings_list, encode_html: true
+  haml :findings_list
 end
 
 # Create a new templated finding
@@ -32,7 +32,7 @@ get '/master/findings/new' do
   @nessusmap = config_options['nessusmap']
   @vulnmap = config_options['vulnmap']
 
-  haml :create_finding, encode_html: true
+  haml :create_finding
 end
 
 # Create the finding in the DB
@@ -136,7 +136,7 @@ get '/master/findings/:id/edit' do
 
   return 'No Such Finding' if @finding.nil?
 
-  haml :findings_edit, encode_html: true
+  haml :findings_edit
 end
 
 # Edit a finding

--- a/routes/report.rb
+++ b/routes/report.rb
@@ -21,7 +21,7 @@ get '/reports/list' do
   # allow the user to set their logo in the configuration options
   @logo = config_options['logo']
 
-  haml :reports_list, encode_html: true
+  haml :reports_list
 end
 
 # Create a report
@@ -29,7 +29,7 @@ get '/report/new' do
   @templates = Xslt.all
   @assessment_types = config_options['report_assessment_types']
   @languages = config_options['languages']
-  haml :new_report, encode_html: true
+  haml :new_report
 end
 
 # Create a report
@@ -74,7 +74,7 @@ get '/report/:id/attachments' do
   xslt = Xslt.first(report_type: @report.report_type)
   @screenshot_names_from_report = xslt.screenshot_names
   @screenshot_names_from_findings
-  haml :list_attachments, encode_html: true
+  haml :list_attachments
 end
 
 get '/report/:id/export_attachments' do
@@ -98,7 +98,7 @@ get '/report/:id/restore_attachments' do
   @report = get_report(@id)
   return 'No Such Report' if @report.nil?
 
-  haml :restore_attachments, encode_html: true
+  haml :restore_attachments
 end
 
 post '/report/:id/restore_attachments' do
@@ -136,7 +136,7 @@ get '/report/:id/import_scan_data' do
   return 'No Such Report' if @report.nil?
 
   @auto_import = config_options['auto_import']
-  haml :import_scan_data, encode_html: true
+  haml :import_scan_data
 end
 
 post '/report/:id/import_scan_data' do
@@ -193,7 +193,7 @@ get '/report/:id/import_nessus' do
   # Query for the first report matching the id
   @report = get_report(id)
 
-  haml :import_nessus, encode_html: true
+  haml :import_nessus
 end
 
 # auto add serpico findings if mapped to nessus ids
@@ -290,7 +290,7 @@ post '/report/:id/import_autoadd' do
     @dup_findings = dup_findings.uniq
     @autoadd_findings = add_findings
   end
-  haml :findings_add, encode_html: true
+  haml :findings_add
 end
 
 # upload burp xml files to be processed
@@ -302,7 +302,7 @@ get '/report/:id/import_burp' do
   # Query for the first report matching the id
   @report = get_report(id)
 
-  haml :import_burp, encode_html: true
+  haml :import_burp
 end
 
 # Upload attachment menu
@@ -316,7 +316,7 @@ get '/report/:id/upload_attachments' do
   return 'No Such Report' if @report.nil?
 
   @attachments = Attachments.all(report_id: id)
-  haml :upload_attachments, encode_html: true
+  haml :upload_attachments
 end
 
 post '/report/:id/upload_attachments' do
@@ -439,7 +439,7 @@ get '/report/:id/edit' do
 
   @report.update(scoring: set_scoring(config_options)) unless @report.scoring
 
-  haml :report_edit, encode_html: true
+  haml :report_edit
 end
 
 # Edit the Report's main information; Name, Consultant, etc.
@@ -451,7 +451,7 @@ get '/report/:id/additional_features' do
 
   return 'No Such Report' if @report.nil?
 
-  haml :additional_features, encode_html: true
+  haml :additional_features
 end
 
 # Edit a report
@@ -484,7 +484,7 @@ get '/report/:id/udo/manage' do
   end
   @udos_templates = UserDefinedObjectTemplates.all
 
-  haml :user_defined_object_manage, encode_html: true
+  haml :user_defined_object_manage
 end
 
 # Create new user defined objects. Get => the user chose the udo values
@@ -496,7 +496,7 @@ get '/report/:id/udo/:udo_template_id/create' do
   @udo_template = UserDefinedObjectTemplates.get(params[:udo_template_id])
   return 'no Such UDO Template' if @udo_template.nil?
   @udo_template_properties = JSON.parse(@udo_template.udo_properties)
-  haml :user_defined_object_create, encode_html: true
+  haml :user_defined_object_create
 end
 
 # Create new user defined objects. Post => the UDO is stored in database
@@ -550,7 +550,7 @@ get '/report/:id/udo/:udo_id/edit' do
   @udo_template = UserDefinedObjectTemplates.get(@udo_to_edit.template_id)
   @udo_template_properties = JSON.parse(@udo_template.udo_properties)
   @udo_to_edit_properties = JSON.parse(@udo_to_edit.udo_properties)
-  haml :user_defined_object_edit, encode_html: true
+  haml :user_defined_object_edit
 end
 
 # Edit an UDO. Post => value stored in db
@@ -622,7 +622,7 @@ get '/report/:id/user_defined_variables' do
     @user_variables = config_options['user_defined_variables']
   end
 
-  haml :user_defined_variable, encode_html: true
+  haml :user_defined_variable
 end
 
 # TODO: this route needs proper comments, it is very confusing
@@ -698,7 +698,7 @@ get '/report/:id/findings' do
                              else
                                false
                              end
-  haml :findings_list, encode_html: true
+  haml :findings_list
 end
 
 # Generate a status report from the current findings
@@ -812,7 +812,7 @@ get '/report/:id/findings_add' do
   # Query for all Findings
   @findings = TemplateFindings.all(approved: true, order: [:title.asc])
 
-  haml :findings_add, encode_html: true
+  haml :findings_add
 end
 
 # Add a finding to the report
@@ -872,7 +872,7 @@ post '/report/:id/findings_add' do
 
   @findings, @dread, @cvss, @cvssv3, @risk, @riskmatrix,@nist800 = get_scoring_findings(@report)
 
-  haml :findings_list, encode_html: true
+  haml :findings_list
 end
 
 # Create a new finding in the report
@@ -891,7 +891,7 @@ get '/report/:id/findings/new' do
 
   @findings, @dread, @cvss, @cvssv3, @risk, @riskmatrix,@nist800 = get_scoring_findings(@report)
 
-  haml :create_finding, encode_html: true
+  haml :create_finding
 end
 
 # Create the finding in the DB
@@ -959,7 +959,7 @@ get '/report/:id/findings/:finding_id/edit' do
 
   @findings, @dread, @cvss, @cvssv3, @risk, @riskmatrix,@nist800 = get_scoring_findings(@report)
 
-  haml :findings_edit, encode_html: true
+  haml :findings_edit
 end
 
 # Edit a finding in the report
@@ -1574,7 +1574,7 @@ get '/report/:id/text_status' do
   # add the findings
   @findings = Findings.all(report_id: id)
 
-  haml :text_status, encode_html: true
+  haml :text_status
 end
 
 # generate an asciidoc version of current findings
@@ -1661,7 +1661,7 @@ get '/report/:id/presentation' do
     end
   end
 
-  haml :presentation, encode_html: true, layout: false
+  haml :presentation, layout: false
 end
 
 # export presentation of current report in html format, inside a zip
@@ -1797,7 +1797,7 @@ get '/report/:id/msfsettings' do
   @vulnmap = config_options['vulnmap']
   @msfsettings = RemoteEndpoints.first(report_id: id)
 
-  haml :msfsettings, encode_html: true
+  haml :msfsettings
 end
 
 # set msf rpc settings for report
@@ -1855,7 +1855,7 @@ get '/report/:id/hosts' do
   res = rpc.call('db.hosts', limit: 10_000)
   @hosts = res['hosts']
 
-  haml :dbhosts, encode_html: true
+  haml :dbhosts
 end
 
 # display services from msf db
@@ -1885,7 +1885,7 @@ get '/report/:id/services' do
   res = rpc.call('db.services', limit: 10_000, only_up: true)
   @services = res['services']
 
-  haml :dbservices, encode_html: true
+  haml :dbservices
 end
 
 # display vulns from msf db
@@ -1914,7 +1914,7 @@ get '/report/:id/vulns' do
   res = rpc.call('db.vulns', limit: 10_000)
   @vulns = res['vulns']
 
-  haml :dbvulns, encode_html: true
+  haml :dbvulns
 end
 
 # autoadd vulns from msf db
@@ -2000,7 +2000,7 @@ get '/report/:id/import/vulns' do
     @dup_findings = dup_findings.uniq
     @autoadd_findings = add_findings
   end
-  haml :findings_add, encode_html: true
+  haml :findings_add
 end
 
 # get enabled plugins
@@ -2022,5 +2022,5 @@ get '/report/:id/report_plugins' do
     a['link'] = pl['link']
     @menu.push(a)
   end
-  haml :enabled_plugins, encode_html: true
+  haml :enabled_plugins
 end


### PR DESCRIPTION
Removes the bothersome warning about `:encode_html` not being a valid template engine option.

Quiet is good, quiet is nice.

This closes #441.