### PR TITLE
Made plugins aware of report generation and deletion

### DIFF
--- a/helpers/plugin_listener.rb
+++ b/helpers/plugin_listener.rb
@@ -2,13 +2,13 @@
 class PluginListener
   # By design, a PluginListener will return no information when notified.
   # => This should be overridden by each plugin that need to add content into a report XML
-  def notify_report_generated(report_id)
+  def notify_report_generated(report_object)
     return ""
   end
 
     # By design, a PluginListener will do no cleanup when notified.
     # => This should be overridden by each plugin that need to cleanup his local database when reports are deleted.
-  def notify_report_deleted(report_id)
+  def notify_report_deleted(report_object)
     return
   end
 end

--- a/helpers/plugin_listener.rb
+++ b/helpers/plugin_listener.rb
@@ -1,0 +1,14 @@
+# For more information on the behavior of this class, look at helpers/plugin_notifier.rb
+class PluginListener
+  # By design, a PluginListener will return no information when notified.
+  # => This should be overridden by each plugin that need to add content into a report XML
+  def notify_report_generated(report_id)
+    return ""
+  end
+
+    # By design, a PluginListener will do no cleanup when notified.
+    # => This should be overridden by each plugin that need to cleanup his local database when reports are deleted.
+  def notify_report_deleted(report_id)
+    return
+  end
+end

--- a/helpers/plugin_notifier.rb
+++ b/helpers/plugin_notifier.rb
@@ -1,3 +1,4 @@
+require 'sinatra'
 require 'singleton'
 
 # This class is used to reproduce an Observer-like design pattern
@@ -27,18 +28,18 @@ class PluginNotifier
     @plugins.remove observed_plugin
   end
 
-  def notify_report_generated(report_id)
+  def notify_report_generated(report_object)
     returned_xml = "<plugins>\n"
 
     @plugins.each { |observer|
-      returned_xml << observer.notify_report_generated(report_id)
+      returned_xml << observer.notify_report_generated(report_object)
     }
 
     returned_xml << "</plugins>\n"
     return returned_xml
   end
 
-  def notify_report_deleted(report_id)
-    @plugins.each { |observer| observer.notify_report_deleted(report_id) }
+  def notify_report_deleted(report_object)
+    @plugins.each { |observer| observer.notify_report_deleted(report_object) }
   end
 end

--- a/helpers/plugin_notifier.rb
+++ b/helpers/plugin_notifier.rb
@@ -1,0 +1,44 @@
+require 'singleton'
+
+# This class is used to reproduce an Observer-like design pattern
+# => Every plugin that inherits the PluginListener class will receive the events listed in this class
+#
+# => Do note that the methods in this class should remain generic. If you need something that only applies to 1YWoswqCayG3vIFHuRmnku8g
+#    plugin, consider doing it elsewhere.
+class PluginNotifier
+  include Singleton
+
+  def initialize
+    @plugins = []
+  end
+
+  # Add a plugin PluginListener
+  # => The listener will be notified when a report is generated so he can add XML content into the report
+  # => He will also be notified when a report is deleted so he can cleanup his local database
+  def attach_plugin(observed_plugin)
+    if observed_plugin and observed_plugin.class <= PluginListener
+      @plugins.push observed_plugin
+    else
+      raise 'All observed classes must be non-null and inherit from the PluginListener class.'
+    end
+  end
+
+  def detach_plugin(observed_plugin)
+    @plugins.remove observed_plugin
+  end
+
+  def notify_report_generated(report_id)
+    returned_xml = "<plugins>\n"
+
+    @plugins.each { |observer|
+      returned_xml << observer.notify_report_generated(report_id)
+    }
+
+    returned_xml << "</plugins>\n"
+    return returned_xml
+  end
+
+  def notify_report_deleted(report_id)
+    @plugins.each { |observer| observer.notify_report_deleted(report_id) }
+  end
+end

--- a/routes/report.rb
+++ b/routes/report.rb
@@ -414,12 +414,14 @@ get '/report/remove/:id' do
     # get all findings and udos associated with the report
     findings = Findings.all(report_id: id)
     udos = UserDefinedObjects.all(report_id: id)
+
+    # Notify the plugins that the report will be deleted
+    PluginNotifier.instance.notify_report_deleted(report)
+
     # delete the entries
     findings.destroy
     udos.destroy
     report.destroy
-
-    PluginNotifier.instance.notify_report_deleted(id)
   end
   serpico_log("Report deleted, Report #{id}")
   redirect to('/reports/list')
@@ -1375,7 +1377,7 @@ get '/report/:id/generate' do
   all_appendices_xml += "</appendices>\n"
 
   # We notify all the plugins to get their output and add it to the report xml
-  plugins_xml = PluginNotifier.instance.notify_report_generated(id)
+  plugins_xml = PluginNotifier.instance.notify_report_generated(@report)
 
   # we bring all xml together
   report_xml = "<report>#{CGI.unescapeHTML(@report.to_xml)}#{udv}#{findings_xml}#{udo_xml}#{services_xml}#{hosts_xml}#{all_appendices_xml}#{plugins_xml}</report>"


### PR DESCRIPTION
The biggest problem I had while designing plugins is that there is no way of adding content into a report from a plugin without having to resort to some dirty hack like adding data in the UDO's or UDV's. There is also the problem of cleaning up when a report is deleted. If a plugin local database refers to a report by id, there is no way to know if that data is still valid without querying the master database.

I added an Observer-like design pattern to handle these problems. This way, the main Serpico project doesn't have to be aware that the plugins exist, but the plugins can now insert XML content into the report and be notified when a report is deleted.

To use this, simply create a new class in your plugin and make it extend the PluginListener class. For instance, you could create the plugins/SamplePlugin/helpers/sample_plugin_listener.rb file with the following code :
```
require './helpers/plugin_listener'

class SamplePluginListener < PluginListener
  def notify_report_generated(report_id)
    return "<sample_plugin>My Data Here</sample_plugin>"
  end

  def notify_report_deleted(report_id)
    DataMapper.repository(:samples) {
        @sample = Samples.first(:report_id => report_id)
        @sample.destroy
    }
    return
  end
end
```
Then, register the plugin listener with the observer to be notified when these events happen. TO do so, add the following line in the routes.rb file of your plugin
```
require './plugins/SamplePlugin/helpers/sample_plugin_listener'

PluginNotifier.instance.attach_plugin(SamplePluginListener.new)
```

If the PR is merged, I will gladly document this a bit more in the Serpico Wiki and add an example in the TestPlugin.