### PR TITLE
Reverted msfrpc-client to v1.0.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'nokogiri' , '1.8.1'
 gem 'do_sqlite3', '0.10.17'
 gem 'data_mapper', '1.2.0'
 gem 'dm-sqlite-adapter', '1.2.0'
-gem 'msfrpc-client', '1.1.1'
+gem 'msfrpc-client', '1.0.3'
 gem 'odle'
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,9 +65,9 @@ GEM
     json_pure (1.8.6)
     metasm (1.0.3)
     mini_portile2 (2.3.0)
-    msfrpc-client (1.1.1)
-      msgpack (~> 1)
-      rex (~> 2)
+    msfrpc-client (1.0.3)
+      msgpack (~> 0.5.8)
+      librex (~> 0.0.70)
     msgpack (1.2.4)
     multi_json (1.13.1)
     mustermann (1.0.3)
@@ -110,7 +110,7 @@ DEPENDENCIES
   do_sqlite3 (= 0.10.17)
   haml
   json
-  msfrpc-client (= 1.1.1)
+  msfrpc-client (= 1.0.3)
   net-ldap (~> 0.11)
   nokogiri (= 1.8.1)
   odle


### PR DESCRIPTION
Serpico >=1.2.2 uses a newer version of msfrpc-client (1.1.1) which breaks the ability to authenticate with msfrpcd.  Serpico version 1.2.1 used msfrpc-client 1.0.3, and is the last known working release.  To fix, msfrpc-client was downgraded to v1.0.3 in the Gemfile and Gemfile.lock files, and the appropriate additional dependences (librex and msgpack) were adjusted to accommodate the change.  