### PR TITLE
Fixed some UI bugs related to the attachments handling in the findings pages

### DIFF
--- a/routes/report.rb
+++ b/routes/report.rb
@@ -885,7 +885,7 @@ get '/report/:id/findings/new' do
   temp_attaches = Attachments.all(report_id: params[:id])
   @attaches = []
   temp_attaches.each do |ta|
-    next unless ta.description =~ /png/i || ta.description =~ /jpg/i
+    next unless ta.description =~ /\.png$/i || ta.description =~ /\.jpg$/i || ta.description =~ /\.jpeg$/i
     @attaches.push(ta.description)
   end
 
@@ -953,7 +953,7 @@ get '/report/:id/findings/:finding_id/edit' do
   temp_attaches = Attachments.all(report_id: id)
   @attaches = []
   temp_attaches.each do |ta|
-    next unless ta.description =~ /png/i || ta.description =~ /jpg/i
+    next unless ta.description =~ /\.png$/i || ta.description =~ /\.jpg$/i || ta.description =~ /\.jpeg$/i
     @attaches.push(ta.description)
   end
 

--- a/routes/report.rb
+++ b/routes/report.rb
@@ -59,12 +59,16 @@ get '/report/:id/attachments' do
   @screenshot_names_from_findings = {}
   # fetching screenshots names in findings
   findings = Findings.all(report_id: id)
+
   findings.each do |find|
-    next unless find.poc
+    next unless find.overview or find.poc or find.remediation or find.notes
+
+    text = find.overview + find.poc + find.remediation + find.notes
+
     @screenshot_names_from_findings[find.id] = []
     # for each finding, we extract the screenshot name in the poc field.
     # screenshot names are like this : [!!screenshotnames.png!!]
-    find.poc.to_s.split('<paragraph>').each do |pp|
+    text.to_s.split('<paragraph>').each do |pp|
       next unless pp =~ /\[\!\!/
       @screenshot_names_from_findings[find.id] << pp.split('[!!')[1].split('!!]').first
     end

--- a/views/create_finding.haml
+++ b/views/create_finding.haml
@@ -559,28 +559,6 @@
       %label.control-label{ :for => "poc" } Proof of Concept
       .controls
         %textarea.input-xxlarge.allowMarkupShortcut#poc{ :rows => "10", :name => "poc" }
-    - attachments=''
-    - if @attaches
-      - @attaches.each do |attach|
-        - attachments = attachments + "{name: '#{attach}' },"
-    / autosuggest code is care of bootstrap-suggest.js
-    :javascript
-      var files = [
-        #{attachments}
-      ];
-        $('#pocu').suggest('[', {
-          data: files,
-          filter: {
-              casesensitive: true,
-              limit: 10
-            },
-          map: function(file) {
-            return {
-              value: '!!'+file.name+'!!]',
-              text: '<strong>'+file.name+'</strong>'
-            }
-          }
-        })
     - if !@master
       .control-group
         %label.control-label{ :for => "affected_hosts" } Affected Hosts
@@ -632,6 +610,30 @@
     %input.btn.btn-default{ :type => "submit", :value => "Save" }
     %a.btn.btn-default{ :href => "#{id_r}" }
       Cancel
+
+- if @attaches
+  - attachments=''
+  - @attaches.each do |attach|
+    - attachments = attachments + "{name: '#{attach}'},"
+  / autosuggest code is care of bootstrap-suggest.js
+  :javascript
+    var files = [
+      #{attachments}
+    ];
+    var suggestSettings =
+    $('#poc, #overview, #remediation, #notes').suggest('[', {
+      data: files,
+      filter: {
+        casesensitive: true,
+        limit: 10
+      },
+      map: function(file) {
+        return {
+          value: '!!'+file.name+'!!]',
+          text: '<strong>'+file.name+'</strong>'
+          }
+      }
+    })
 
 -if @cvss
   :javascript

--- a/views/findings_edit.haml
+++ b/views/findings_edit.haml
@@ -771,29 +771,6 @@
           - if @finding
             - if @finding.poc
               #{meta_markup(@finding.poc)}
-    - attachments=''
-    - if @attaches
-      - @attaches.each do |attach|
-        - attachments = attachments + "{name: '#{attach}'},"
-    / autosuggest code is care of bootstrap-suggest.js
-    :javascript
-      var files = [
-        #{attachments}
-      ];
-        $('#pocu').suggest('[', {
-          data: files,
-          filter: {
-              casesensitive: true,
-              limit: 10
-            },
-          map: function(file) {
-            return {
-              value: '!!'+file.name+'!!]',
-              text: '<strong>'+file.name+'</strong>'
-            }
-          }
-        })
-
     - if !@master
       .control-group
         %label.control-label{ :for => "affected_hosts" } Affected Hosts/URLs
@@ -805,7 +782,7 @@
     .control-group
       %label.control-label{ :for => "remediation" } Remediation
       .controls
-        %textarea.input-xxlarge.allowMarkupShortcut{ :rows => "10", :name => "remediation" }
+        %textarea.input-xxlarge.allowMarkupShortcut#remediation{ :rows => "10", :name => "remediation" }
           - if @finding
             - if @finding.remediation
               #{meta_markup(@finding.remediation)}
@@ -822,9 +799,9 @@
         %i.icon-chevron-down#actionButton{ "data-toggle" => "collapse", "data-target" => "#info_2" }
         .info.collapse.out#info_2
           %label
-            Notes
+            Notesnotes
           .controls
-          %textarea.input-xxlarge.allowMarkupShortcut{ :rows => "10", :name => "notes" }
+          %textarea.input-xxlarge.allowMarkupShortcut#notes{ :rows => "10", :name => "notes" }
             - if @finding
               - if @finding.notes
                 #{meta_markup(@finding.notes)}
@@ -855,6 +832,31 @@
     %input.btn.btn-default{ :type => "submit", :value => "Save" }
     %a.btn.btn-default{ :href => "#{id_r}" }
       Cancel
+
+
+- if @attaches
+  - attachments=''
+  - @attaches.each do |attach|
+    - attachments = attachments + "{name: '#{attach}'},"
+  / autosuggest code is care of bootstrap-suggest.js
+  :javascript
+    var files = [
+      #{attachments}
+    ];
+    var suggestSettings =
+    $('#pocu, #overview, #remediation, #notes').suggest('[', {
+      data: files,
+      filter: {
+        casesensitive: true,
+        limit: 10
+      },
+      map: function(file) {
+        return {
+          value: '!!'+file.name+'!!]',
+          text: '<strong>'+file.name+'</strong>'
+          }
+      }
+    })
 
 -if @cvss
   :javascript

--- a/views/findings_edit.haml
+++ b/views/findings_edit.haml
@@ -799,7 +799,7 @@
         %i.icon-chevron-down#actionButton{ "data-toggle" => "collapse", "data-target" => "#info_2" }
         .info.collapse.out#info_2
           %label
-            Notesnotes
+            Notes
           .controls
           %textarea.input-xxlarge.allowMarkupShortcut#notes{ :rows => "10", :name => "notes" }
             - if @finding


### PR DESCRIPTION
I fixed a few bugs related to the way attachments were handled in the findings.

1. The platform allows you to insert attachments in almost any field of the report which is great. However, the auto-complete suggestion prompt was only displayed in the POC text box. We are sometimes adding images in other fields and you have to go back and forth between the "List Attachments" page and your new finding to get the correct name. I added the suggestion prompt in the Overview, Remediation and Notes field to fix this issue.
2. The "List Attachment" page did not show that images were included in a finding if it was somewhere else than in the POC field.
3. I added jpeg images in the suggestion box since the platform allows .jpeg images but the suggestion box did not include them. 
4. This is a small detail, but if you upload an attachment called annex-images-jpg.xml, it will be displayed in the suggestion box since the regex only checks for the presence of the jpg string. I changed the regex to match only files ending with .jpg, .jpeg and .png. 