### PR TITLE
Choose/When Style Bug Fix

### DIFF
--- a/helpers/xslt_generation.rb
+++ b/helpers/xslt_generation.rb
@@ -773,7 +773,21 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 ###########################
 # ÷ - otherwise . Used in XSLT choose loops
-	document = document.gsub('÷',"</w:t></w:r></w:p></xsl:when><xsl:otherwise><w:p><w:r><w:t>")
+  otherwise_results = ""
+  document.each_line('÷') { |line|
+    paragraph_style = ""
+    paragraph_style_index = line.reverse.index("<w:pPr>".reverse)
+    paragraph_index = line.reverse.index(/[ >]p:w</)
+
+    if paragraph_style_index < paragraph_index
+      paragraph_style_index = paragraph_style_index + "<w:pPr>".length
+      paragraph_style_end_index = line.reverse.index("</w:pPr>".reverse)
+      paragraph_style = line.reverse[paragraph_style_end_index, (paragraph_style_index - paragraph_style_end_index)].reverse
+    end
+
+    otherwise_results << line.gsub('÷',"</w:t></w:r></w:p></xsl:when><xsl:otherwise><w:p>" + paragraph_style + "<w:r><w:t>")
+  }
+	document = otherwise_results
 
 ###########################
 # ¥ - ends an if statement

--- a/helpers/xslt_generation.rb
+++ b/helpers/xslt_generation.rb
@@ -779,10 +779,12 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
     paragraph_style_index = line.reverse.index("<w:pPr>".reverse)
     paragraph_index = line.reverse.index(/[ >]p:w</)
 
-    if paragraph_style_index < paragraph_index
-      paragraph_style_index = paragraph_style_index + "<w:pPr>".length
-      paragraph_style_end_index = line.reverse.index("</w:pPr>".reverse)
-      paragraph_style = line.reverse[paragraph_style_end_index, (paragraph_style_index - paragraph_style_end_index)].reverse
+    if paragraph_style_index and paragraph_index
+      if paragraph_style_index < paragraph_index
+        paragraph_style_index = paragraph_style_index + "<w:pPr>".length
+        paragraph_style_end_index = line.reverse.index("</w:pPr>".reverse)
+        paragraph_style = line.reverse[paragraph_style_end_index, (paragraph_style_index - paragraph_style_end_index)].reverse
+      end
     end
 
     otherwise_results << line.gsub('÷',"</w:t></w:r></w:p></xsl:when><xsl:otherwise><w:p>" + paragraph_style + "<w:r><w:t>")


### PR DESCRIPTION
In a Word template, if you have a choose when structure that doesn't default to the "Normal" style, it will be override when the report is generated.

For instance, if I have those styles that are defined in my Word document
![image](https://user-images.githubusercontent.com/3847037/47223199-a4471380-d386-11e8-9586-9a974594c68d.png)

and this piece of code 
```
¬poc/paragraph¬ µCONDITIONALµ π.π
ƒitalicsƒπ.π
ƒh4ƒπ.π
÷ π.π ≠
```
where the `ƒitalicsƒ` section has the normal style + italic attribute, the `ƒh4ƒ` section has the normal style + bold attribute and I want the rest of the text to be printed in the "Code" style.

Currently, Serpico will override the  `÷ π.π ≠` and set it to "Normal" in my generated report.

To avoid this, I added a piece of code that goes back into the XML structure and copies the w:rPr attribute (styling) into the new node created for the default text.