### PR TITLE
Made Findings Assessment Types customizable just like report assessment types

### DIFF
--- a/config.json.defaults
+++ b/config.json.defaults
@@ -37,6 +37,7 @@
 
   ],
   "report_assessment_types": ["Network Internal","External","Web application","Physical","Social engineering","Configuration audit"],
+  "findings_assessment_types": ["External", "Internal", "Internal/External", "Wireless", "Web Application", "DoS"],
   "threshold": "2",
   "log_file": "./log/serpico.log",
   "show_exceptions": false,

--- a/server.rb
+++ b/server.rb
@@ -14,7 +14,13 @@ class Server < Sinatra::Application
   set :config_options, config_options
   ## Global variables
   set :finding_types, config_options['finding_types']
-  set :assessment_types, ['External', 'Internal', 'Internal/External', 'Wireless', 'Web Application', 'DoS']
+
+  # set the report_assessment_types for <= 1.3.0 versions of Serpico
+  unless config_options['findings_assessment_types']
+    config_options['findings_assessment_types'] = ['External', 'Internal', 'Internal/External', 'Wireless', 'Web Application', 'DoS']
+  end
+  set :assessment_types, config_options['findings_assessment_types']
+
   set :status, ['EXPLOITED']
   set :show_exceptions, config_options['show_exceptions']
 
@@ -92,11 +98,11 @@ class Server < Sinatra::Application
   # Risk Matrix
   set :severity, %w[Low Medium High]
   set :likelihood, %w[Low Medium High]
-  
+
   # NIST800
   set :nist_likelihood, ['Low','Moderate','High']
   set :nist_impact, ['Informational','Low','Moderate','High','Critical']
-  
+
   if config_options['cvssv2_scoring_override']
     if config_options['cvssv2_scoring_override'] == 'true'
       set :cvssv2_scoring_override, true


### PR DESCRIPTION
The report assessment types are customizable via the config.json file, but the findings assessment type were hardcoded in a route file.

We have reports that contain more than only one type of assessment and we rely on the findings to map them to the correct section of the report. To support this use case (and probably others), I made the findings assessment type loaded via the config.json file.

The change is retro-compatible with versions that doesn't have that element in the config file.