### PR TITLE
Fixed a crash when the attachment list is loaded with uninitialized findings

### DIFF
--- a/routes/report.rb
+++ b/routes/report.rb
@@ -63,7 +63,19 @@ get '/report/:id/attachments' do
   findings.each do |find|
     next unless find.overview or find.poc or find.remediation or find.notes
 
-    text = find.overview + find.poc + find.remediation + find.notes
+    text = ""
+    if find.overview
+      text = text + find.overview
+    end
+    if find.poc
+      text = text + find.poc
+    end
+    if find.remediation
+      text = text + find.remediation
+    end
+    if find.notes
+      text = text + find.notes
+    end
 
     @screenshot_names_from_findings[find.id] = []
     # for each finding, we extract the screenshot name in the poc field.


### PR DESCRIPTION
When findings are created but not completed (say you have created a new finding with only a title and did not go back to add content), the attachment list page will yield an error because it tries to concatenate fields with null values.

This should be very rare in a day to day use of the platform, but I added a safety check anyways just in case.